### PR TITLE
ci: ISA-scope benchmark caches so target-cpu=native is reuse-safe

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -216,9 +216,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Namespace caches by host ISA
+        # We build with `-Ctarget-cpu=native` for best-possible codegen (math/crypto libs use
+        # ISA extensions on both x86_64 and aarch64). But sccache, the host-binary cache, and
+        # rust-cache all key on the literal flag string "-Ctarget-cpu=native", which is constant
+        # across CPUs — so a native artifact built on one microarchitecture can be served to a
+        # weaker one and crash with SIGILL (exit 132). Fingerprint the *resolved* host feature
+        # set and partition every cache by it: we keep native codegen, but never reuse an
+        # artifact across different CPUs.
+        run: |
+          arch=$(uname -m)
+          ISA=$(rustc -Ctarget-cpu=native --print cfg | grep '^target_feature=' | sort | sha256sum | cut -d' ' -f1 | head -c12)
+          PREFIX="isa-${arch}-${ISA}"
+          echo "HOST_ISA_KEY=${arch}-${ISA}" >> "$GITHUB_ENV"
+          echo "SCCACHE_S3_KEY_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
+          # sccache only reads SCCACHE_S3_KEY_PREFIX when its server boots, and the action above
+          # already started one without the prefix. Restart it so the ISA-scoped prefix takes
+          # effect (stop, then start again with the prefix exported into this shell).
+          export SCCACHE_S3_KEY_PREFIX="${PREFIX}"
+          sccache --stop-server || true
+          sccache --start-server
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          key: ${{ env.HOST_ISA_KEY }}
 
       - name: Add workflow inputs to summary
         run: |
@@ -378,7 +399,9 @@ jobs:
           JEMALLOC_CONF_HASH=$(echo "${JEMALLOC_SYS_WITH_MALLOC_CONF}" | sha256sum | cut -d' ' -f1 | head -c8)
           FEATURES_HASH=$(echo "${FEATURES}" | sha256sum | cut -d' ' -f1 | head -c8)
           HOST_PROFILE=${{ steps.set-build-profiles.outputs.host_profile }}
-          echo "host_cache_key=host-${TAG}-${arch}-${HOST_PROFILE}-${RUSTFLAGS_HASH}-${JEMALLOC_CONF_HASH}-${FEATURES_HASH}" >> $GITHUB_OUTPUT
+          # ${HOST_ISA_KEY} keeps the prebuilt host binary from being restored onto a CPU with a
+          # different resolved ISA than it was compiled for (see "Namespace caches by host ISA").
+          echo "host_cache_key=host-${TAG}-${arch}-${HOST_PROFILE}-${RUSTFLAGS_HASH}-${JEMALLOC_CONF_HASH}-${FEATURES_HASH}-${HOST_ISA_KEY}" >> $GITHUB_OUTPUT
 
       - name: Restore Guest ELF from cache
         id: cache-guest-elf-restore


### PR DESCRIPTION
## Problem

The reth benchmark builds the host binary with `-Ctarget-cpu=native` so codegen uses every ISA extension the build host supports (the math/crypto libs rely on these on both x86_64 and aarch64).

Those build artifacts are cached three ways — sccache (object files, shared S3 bucket), the host-binary cache, and `Swatinem/rust-cache` (the `target/` dir). All three key on the **literal `RUSTFLAGS` string**. The catch: `-Ctarget-cpu=native` is the *same string* on every machine but means something *different* on each — the actual instructions baked into the output depend on the CPU that did the compile.

So whenever the runner fleet has more than one CPU microarchitecture, a cached `native` artifact built on a richer CPU can be restored onto a weaker one. The binary then executes instructions that CPU doesn't have and dies at runtime with **illegal instruction / SIGILL (exit 132)**. It's intermittent — it only triggers when a cache entry crosses from a richer to a weaker CPU.

## Fix

Keep `-Ctarget-cpu=native` (we still want best-possible codegen). Just make the cache keys honest: fingerprint the **resolved** host feature set — `rustc -Ctarget-cpu=native --print cfg`, i.e. the actual list of enabled `target_feature`s — and fold it into every cache namespace:

- `SCCACHE_S3_KEY_PREFIX=isa-<arch>-<hash>` (plus a `sccache --stop-server`, since sccache only reads the prefix at server start)
- `Swatinem/rust-cache`'s `key:`
- the host-binary `host_cache_key`

A `native` artifact can now only be reused on a CPU with the identical feature set; any other CPU gets a clean cache miss and rebuilds.

## Does this bloat the caches?

No meaningful churn. The extra key dimension is the **number of distinct CPU microarchitectures** the benchmarks run on (a handful), not the number of runs or commits. The fingerprint is deterministic per CPU model, so each runner type keeps hitting its own warm namespace. The caches are S3-backed (runs-on `s3-cache` + the sccache S3 bucket), not GitHub's size-capped Actions cache, so a small bounded multiplier just costs a little extra S3 storage — no eviction pressure. (And the previously-shared single namespace was already unsafe, so this replaces a broken cache with a correct one.)