### PR TITLE
feat: add CLI for soundness

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -447,6 +447,42 @@ jobs:
           path: target/${{ steps.set-build-profiles.outputs.host_profile }}/${{ env.BIN_NAME }}
           key: ${{ steps.cache-host-binary-restore.outputs.cache-primary-key }}
 
+      - name: Soundness report
+        run: |
+          set -euxo pipefail  # -x: trace each command (to stderr) so it shows in the logs
+          HOST_PROFILE=${{ steps.set-build-profiles.outputs.host_profile }}
+          BIN="./target/${HOST_PROFILE}/${{ env.BIN_NAME }}"
+          # soundness/soundcalc keygen the app + aggregation keys in memory and need no guest ELF,
+          # block input, or proving, so they run off the already-built host binary. The report is
+          # the only thing on stdout (status messages go to stderr), so capture it directly.
+          "$BIN" --mode soundness > soundness.json
+          "$BIN" --mode soundcalc > openvm2.toml
+          jq -e . soundness.json > /dev/null  # sanity-check the captured JSON
+
+          # Render per-layer security bits to the run summary.
+          {
+            echo "### Soundness"
+            echo ""
+            echo "| layer | security bits |"
+            echo "|---|---|"
+            jq -r '.circuits[] | "| \(.name) | \((.security_bits.total * 100 | round) / 100) |"' soundness.json
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Publish the raw report + soundcalc config to the public bucket (the workflow metrics
+          # bucket isn't web-accessible) and link them in the summary so they're viewable.
+          S3_BASE="${{ env.S3_PUBLIC_PATH_BASE }}/soundness/${METRIC_NAME}"
+          URL_BASE="${{ env.S3_PUBLIC_URL_BASE }}/soundness/${METRIC_NAME}"
+          s5cmd cp soundness.json "${S3_BASE}.soundness.json"
+          s5cmd cp openvm2.toml "${S3_BASE}.openvm2.toml"
+          {
+            echo "Artifacts: [soundness.json](${URL_BASE}.soundness.json) · [openvm2.toml](${URL_BASE}.openvm2.toml)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Path to soundness result
+        run: echo "${{ env.S3_PUBLIC_URL_BASE }}/soundness/${METRIC_NAME}.soundness.json"
+
       - name: Restore RPC input cache from S3
         id: restore-rpc-input-cache
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,6 +7496,7 @@ dependencies = [
  "openvm-transpiler",
  "openvm-verify-stark-host",
  "reth-ethereum-primitives",
+ "serde",
  "serde_json",
  "tokio",
  "toml 0.9.5",

--- a/bin/reth-benchmark/Cargo.toml
+++ b/bin/reth-benchmark/Cargo.toml
@@ -22,6 +22,7 @@ clap_builder = "4.5.34"
 bincode = { workspace = true, features = ["std"] }
 bitcode.workspace = true
 hex = "0.4.3"
+serde.workspace = true
 serde_json.workspace = true
 eyre.workspace = true
 tokio.workspace = true

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -261,7 +261,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     dotenv::dotenv().ok();
 
     #[cfg(feature = "cuda")]
-    println!("CUDA Backend Enabled");
+    eprintln!("CUDA Backend Enabled");
 
     let mut vm_config = reth_vm_config();
     vm_config.as_mut().set_segmentation_max_memory(args.benchmark.segment_max_memory);

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -54,6 +54,7 @@ use tracing::{info, info_span};
 
 mod cli;
 use cli::ProviderArgs;
+mod soundness;
 
 /// Enum representing the execution mode of the host executable.
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -81,6 +82,12 @@ pub enum BenchMode {
     GenerateVmVkey,
     /// Dump per-AIR statistics and exit.
     DumpAirStats,
+    /// Print the computed per-component security bits of the app and aggregation layers to stdout
+    /// and exit.
+    Soundness,
+    /// Print the `soundcalc`-compatible config (TOML) for the app and aggregation layers to stdout
+    /// and exit. Feed this to github.com/ethereum/soundcalc to compute the authoritative bits.
+    Soundcalc,
 }
 
 impl std::fmt::Display for BenchMode {
@@ -99,6 +106,8 @@ impl std::fmt::Display for BenchMode {
             Self::Keygen => write!(f, "keygen"),
             Self::GenerateVmVkey => write!(f, "generate_vm_vkey"),
             Self::DumpAirStats => write!(f, "dump_air_stats"),
+            Self::Soundness => write!(f, "soundness"),
+            Self::Soundcalc => write!(f, "soundcalc"),
         }
     }
 }
@@ -296,6 +305,9 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         let p = args.output_dir.join("agg.pk");
         p.exists().then_some(p)
     });
+    // Whether we're running off persistent on-disk keys (vs. generating them on the fly). The
+    // soundness modes prefer persisted keys but fall back to in-memory keygen, noting it on stderr.
+    let (app_pk_loaded, agg_pk_loaded) = (app_pk_path.is_some(), agg_pk_path.is_some());
 
     let mut sdk_builder = Sdk::builder().agg_tree_config(args.benchmark.agg_tree_config);
 
@@ -331,6 +343,47 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     if matches!(args.mode, BenchMode::DumpAirStats) {
         dump_air_stats(&sdk, &args.air_stats_path)?;
+        return Ok(());
+    }
+
+    if matches!(args.mode, BenchMode::Soundness | BenchMode::Soundcalc) {
+        use soundness::{security_bits_report, Layer, SoundcalcConfig};
+
+        // Prefer persisted keys; fall back to in-memory keygen when they're absent. Note it on
+        // stderr since keygen is slow and the report then reflects the current params rather than
+        // a saved key set (stdout stays clean for the report itself).
+        let missing: Vec<&str> =
+            [(!app_pk_loaded).then_some("app.pk"), (!agg_pk_loaded).then_some("agg.pk")]
+                .into_iter()
+                .flatten()
+                .collect();
+        if !missing.is_empty() {
+            eprintln!(
+                "{} not found; generating proving keys in memory (run `--mode keygen` to persist)",
+                missing.join(" and "),
+            );
+        }
+
+        // The full proof stack: app, then the leaf / internal-for-leaf / internal-recursive
+        // aggregation layers. Each layer's parameters come from the loaded (or freshly generated)
+        // proving keys, so the output reflects this prover's exact production parameters.
+        let agg_pk = sdk.agg_pk();
+        let layers: Vec<Layer> = vec![
+            ("app".to_string(), sdk.app_vk().vk),
+            ("leaf".to_string(), agg_pk.prefix.leaf.get_vk()),
+            ("internal_for_leaf".to_string(), agg_pk.prefix.internal_for_leaf.get_vk()),
+            ("internal_recursive".to_string(), agg_pk.internal_recursive.get_vk()),
+        ];
+
+        match args.mode {
+            BenchMode::Soundness => println!("{}", security_bits_report(&layers)),
+            BenchMode::Soundcalc => {
+                let config =
+                    SoundcalcConfig::from_layers(openvm_sdk::OPENVM_VERSION.to_string(), &layers);
+                println!("{}", toml::to_string(&config)?);
+            }
+            _ => unreachable!(),
+        }
         return Ok(());
     }
 

--- a/bin/reth-benchmark/src/soundness.rs
+++ b/bin/reth-benchmark/src/soundness.rs
@@ -1,0 +1,163 @@
+//! Soundness reporting for the app + aggregation layers, computed from the app + aggregation
+//! proving keys (loaded from disk if present, otherwise generated in memory) so the output
+//! reflects this prover's exact production parameters. Two views are offered:
+//! [`security_bits_report`] runs the stark-backend [`SoundnessCalculator`] and emits the computed
+//! security bits as JSON, and [`SoundcalcConfig`] exports a
+//! [`soundcalc`](https://github.com/ethereum/soundcalc)-compatible config for the external tool.
+
+use openvm_sdk::SC;
+use openvm_stark_sdk::openvm_stark_backend::{
+    keygen::types::MultiStarkVerifyingKey, soundness::SoundnessCalculator, ProximityRegime,
+};
+use serde::Serialize;
+use serde_json::json;
+
+/// A named verifying key for one layer of the proof stack (e.g. `"app"`, `"leaf"`).
+pub(crate) type Layer = (String, MultiStarkVerifyingKey<SC>);
+
+/// Computes per-component security bits for each layer via the stark-backend
+/// [`SoundnessCalculator`] and serializes them as JSON (`{"circuits": [{ "name", "security_bits":
+/// {.., "total"} }]}`). `total` is the binding security level for the layer, so a CI gate is e.g.
+/// `jq -e 'all(.circuits[]; .security_bits.total >= 100)'`.
+pub(crate) fn security_bits_report(layers: &[Layer]) -> String {
+    let circuits: Vec<_> = layers
+        .iter()
+        .map(|(name, vk)| {
+            let s = SoundnessCalculator::calculate_from_vk(vk);
+            json!({
+                "name": name,
+                "security_bits": {
+                    "logup": s.logup_bits,
+                    "gkr_sumcheck": s.gkr_sumcheck_bits,
+                    "gkr_batching": s.gkr_batching_bits,
+                    "zerocheck_sumcheck": s.zerocheck_sumcheck_bits,
+                    "constraint_batching": s.constraint_batching_bits,
+                    "stacked_reduction": s.stacked_reduction_bits,
+                    "whir": s.whir_bits,
+                    "total": s.total_bits,
+                },
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&json!({ "circuits": circuits }))
+        .expect("soundness report serializes")
+}
+
+/// `soundcalc`-compatible config (see github.com/ethereum/soundcalc, `zkvms/openvm2`).
+///
+/// Serialize to TOML with `toml::to_string`.
+#[derive(Serialize)]
+pub(crate) struct SoundcalcConfig {
+    zkevm: Zkevm,
+    swirl: Swirl,
+    circuits: Vec<Circuit>,
+}
+
+#[derive(Serialize)]
+struct Zkevm {
+    name: String,
+    protocol_family: String,
+    version: String,
+    field: String,
+    hash_size_bits: usize,
+}
+
+#[derive(Serialize)]
+struct Swirl {
+    logup_max_interaction_count: u32,
+    logup_log_max_message_length: u32,
+    logup_pow_bits: usize,
+}
+
+#[derive(Serialize)]
+struct Circuit {
+    name: String,
+    l_skip: usize,
+    n_stack: usize,
+    w_stack: usize,
+    log_blowup: usize,
+    whir_folding_pow_bits: usize,
+    whir_mu_pow_bits: usize,
+    explicit_regime: String,
+    /// List-decoding multiplicity bound, emitted only for the `"list"` regime (matching
+    /// soundcalc's openvm2 loader, which reads `explicit_m` only when `explicit_regime ==
+    /// "list"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explicit_m: Option<usize>,
+    whir_num_queries: Vec<usize>,
+    constraint_degree: usize,
+    max_constraints_per_air: usize,
+    num_airs: usize,
+    max_log_trace_height: usize,
+    num_trace_columns: usize,
+    max_interactions_per_air: usize,
+}
+
+impl SoundcalcConfig {
+    /// Builds a soundcalc config with one `[[circuits]]` entry per layer.
+    pub(crate) fn from_layers(version: String, layers: &[Layer]) -> Self {
+        let circuits: Vec<Circuit> =
+            layers.iter().map(|(name, vk)| Circuit::from_vk(name.clone(), vk)).collect();
+
+        // The soundcalc schema has a single global `[swirl]` table; the LogUp parameters are
+        // shared across layers, so take them from the first layer.
+        let logup = &layers[0].1.inner.params.logup;
+
+        Self {
+            zkevm: Zkevm {
+                name: "OpenVM2".to_string(),
+                protocol_family: "SWIRL".to_string(),
+                version,
+                field: "BabyBear^4".to_string(),
+                hash_size_bits: 256,
+            },
+            swirl: Swirl {
+                logup_max_interaction_count: logup.max_interaction_count,
+                logup_log_max_message_length: logup.log_max_message_length,
+                logup_pow_bits: logup.pow_bits,
+            },
+            circuits,
+        }
+    }
+}
+
+impl Circuit {
+    fn from_vk(name: String, vk: &MultiStarkVerifyingKey<SC>) -> Self {
+        let params = &vk.inner.params;
+
+        let mut max_constraints_per_air = 0;
+        let mut max_interactions_per_air = 0;
+        let mut num_trace_columns = 0;
+        for air_vk in &vk.inner.per_air {
+            max_constraints_per_air = max_constraints_per_air
+                .max(air_vk.symbolic_constraints.constraints.constraint_idx.len());
+            max_interactions_per_air =
+                max_interactions_per_air.max(air_vk.symbolic_constraints.interactions.len());
+            num_trace_columns += air_vk.params.width.total_width();
+        }
+
+        let (explicit_regime, explicit_m) = match params.whir.proximity.initial_round() {
+            ProximityRegime::UniqueDecoding => ("unique".to_string(), None),
+            ProximityRegime::ListDecoding { m } => ("list".to_string(), Some(m)),
+        };
+
+        Self {
+            name,
+            l_skip: params.l_skip,
+            n_stack: params.n_stack,
+            w_stack: params.w_stack,
+            log_blowup: params.log_blowup,
+            whir_folding_pow_bits: params.whir.folding_pow_bits,
+            whir_mu_pow_bits: params.whir.mu_pow_bits,
+            explicit_regime,
+            explicit_m,
+            whir_num_queries: params.whir.rounds.iter().map(|r| r.num_queries).collect(),
+            constraint_degree: params.max_constraint_degree,
+            max_constraints_per_air,
+            num_airs: vk.inner.per_air.len(),
+            max_log_trace_height: params.log_stacked_height(),
+            num_trace_columns,
+            max_interactions_per_air,
+        }
+    }
+}


### PR DESCRIPTION
feat: add CLI for soundness calculator

Adds two reth-benchmark `--mode`s, both reading the persisted app + aggregation<br>proving keys (run `--mode keygen` first, or pass --app-pk-path/--agg-pk-path)<br>so the output reflects exactly the on-disk key set:

* `soundness`: computes per-component security bits for each layer via the<br> stark-backend `SoundnessCalculator` and prints them to stdout as JSON.
* `soundcalc`: exports a soundcalc-compatible TOML config to stdout, the<br> input consumed by [github.com/ethereum/soundcalc](<http://github.com/ethereum/soundcalc>) to compute the<br> authoritative bits.