### PR TITLE
feat: use rv64 with rvr support branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5311,7 +5311,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "bytemuck",
  "num-bigint",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6541,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "halo2curves-axiom 0.7.2",
  "num-bigint",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-decoder",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-utils"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-decoder",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -6668,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6727,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6769,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6882,12 +6882,12 @@ dependencies = [
 [[package]]
 name = "openvm-decoder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 
 [[package]]
 name = "openvm-deferral-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -6929,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "eyre",
  "openvm-deferral-guest",
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -7011,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-decoder",
  "openvm-ecc-guest",
@@ -7025,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -7091,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
 ]
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7129,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "group 0.13.0",
  "hex-literal",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-adapters"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7533,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "alloy-sol-types",
  "bitcode",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk-config"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "bon",
  "cfg-if",
@@ -7608,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-sha2-guest",
  "sha2 0.10.9",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ndarray",
  "num_enum",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7662,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
 ]
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "openvm-static-verifier"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "halo2-base",
  "itertools 0.14.0",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "elf",
  "eyre",
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-host"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "bitcode",
  "eyre",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -12326,7 +12326,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
  "openvm-riscv-guest",
@@ -12341,12 +12341,12 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 
 [[package]]
 name = "rvr-openvm-ext-algebra"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "num-bigint",
  "openvm-algebra-transpiler",
@@ -12363,7 +12363,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-bigint"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-bigint-transpiler",
  "openvm-instructions",
@@ -12378,7 +12378,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-deferral"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "libloading 0.8.9",
  "openvm-circuit",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ecc"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-ecc-transpiler",
  "openvm-instructions",
@@ -12407,7 +12407,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ffi-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-instructions",
  "openvm-platform",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-keccak"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-instructions",
  "openvm-keccak256-transpiler",
@@ -12429,7 +12429,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-transpiler",
@@ -12442,7 +12442,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-riscv"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "libloading 0.8.9",
  "openvm-circuit",
@@ -12458,7 +12458,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-instructions",
  "openvm-sha2-transpiler",
@@ -12471,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ir"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "serde",
 ]
@@ -12479,7 +12479,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-lift"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "libloading 0.8.9",
  "openvm-instructions",
@@ -12493,7 +12493,7 @@ dependencies = [
 [[package]]
 name = "rvr-state"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "nix",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5311,7 +5311,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "bytemuck",
  "num-bigint",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6541,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "halo2curves-axiom 0.7.2",
  "num-bigint",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-decoder",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-utils"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-decoder",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -6668,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6727,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6769,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -6822,7 +6822,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "cc",
  "glob",
@@ -6858,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6882,12 +6882,12 @@ dependencies = [
 [[package]]
 name = "openvm-decoder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 
 [[package]]
 name = "openvm-deferral-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -6929,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "eyre",
  "openvm-deferral-guest",
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -7011,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-decoder",
  "openvm-ecc-guest",
@@ -7025,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -7091,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
 ]
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7129,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "group 0.13.0",
  "hex-literal",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-adapters"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7462,7 +7462,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "rand 0.9.2",
- "rvr-openvm-ext-rv32im",
+ "rvr-openvm-ext-riscv",
  "rvr-openvm-lift",
  "serde",
  "strum 0.26.3",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7533,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "alloy-sol-types",
  "bitcode",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk-config"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "bon",
  "cfg-if",
@@ -7608,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-sha2-guest",
  "sha2 0.10.9",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ndarray",
  "num_enum",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7662,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
 ]
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-decoder",
  "openvm-instructions",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#27bb74b90bed66f738add281285b703dc47e129a"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "openvm-static-verifier"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "halo2-base",
  "itertools 0.14.0",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "elf",
  "eyre",
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-host"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "bitcode",
  "eyre",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -12326,7 +12326,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
  "openvm-riscv-guest",
@@ -12341,12 +12341,12 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 
 [[package]]
 name = "rvr-openvm-ext-algebra"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "num-bigint",
  "openvm-algebra-transpiler",
@@ -12363,7 +12363,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-bigint"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-bigint-transpiler",
  "openvm-instructions",
@@ -12378,7 +12378,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-deferral"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "libloading 0.8.9",
  "openvm-circuit",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ecc"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-ecc-transpiler",
  "openvm-instructions",
@@ -12407,7 +12407,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ffi-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-instructions",
  "openvm-platform",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-keccak"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-instructions",
  "openvm-keccak256-transpiler",
@@ -12429,7 +12429,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-transpiler",
@@ -12440,14 +12440,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rvr-openvm-ext-rv32im"
+name = "rvr-openvm-ext-riscv"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "libloading 0.8.9",
  "openvm-circuit",
  "openvm-instructions",
- "openvm-platform",
  "openvm-riscv-transpiler",
  "openvm-stark-backend",
  "rand 0.9.2",
@@ -12459,7 +12458,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-instructions",
  "openvm-sha2-transpiler",
@@ -12472,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ir"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "serde",
 ]
@@ -12480,7 +12479,7 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-lift"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "libloading 0.8.9",
  "openvm-instructions",
@@ -12494,7 +12493,7 @@ dependencies = [
 [[package]]
 name = "rvr-state"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "nix",
  "thiserror 1.0.69",

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2332,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
 ]
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "syn 2.0.114",
 ]
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "group",
  "hex-literal",
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "hex-literal",
  "itertools 0.14.0",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-sha2-guest",
  "sha2",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "openvm-platform",
 ]
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#ead16304615e6dbd386c4323496a924c7c145061"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2332,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
 ]
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "syn 2.0.114",
 ]
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "group",
  "hex-literal",
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "hex-literal",
  "itertools 0.14.0",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "openvm-riscv-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-sha2-guest",
  "sha2",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "openvm-platform",
 ]
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#4d410f21fd90a05e7f31627bdd51fbe57a4580a5"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0-rv64#175e08491320c7631340fa3fb8f957a00eb3d4bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",


### PR DESCRIPTION
add rv64 with rvr support for benchmarking. It was done by running `cargo update -p openvm` to use the latest branch with rvr support.

resolves INT-8428