### PR TITLE
fix: expose reth workload construction

### DIFF
--- a/bin/reth-benchmark/src/cli.rs
+++ b/bin/reth-benchmark/src/cli.rs
@@ -1,17 +1,41 @@
-use alloy_provider::{Provider as _, RootProvider};
-use clap::Parser;
+use std::path::PathBuf;
+
+use alloy_provider::{network::Ethereum, Provider as _, RootProvider};
+use clap::Args;
+use openvm_rpc_proxy::DEFAULT_PREIMAGE_CACHE_NIBBLES;
 use url::Url;
 
-/// The arguments for configuring the chain data provider.
-#[derive(Debug, Clone, Parser)]
-pub(super) struct ProviderArgs {
+#[derive(Debug, Clone, Args)]
+pub struct RethInputSource {
+    /// The block number of the block to execute.
+    #[clap(long)]
+    pub block_number: Option<u64>,
+
     /// The rpc url used to fetch data about the block. If not provided, will use the
     /// RPC_{chain_id} env var.
     #[clap(long)]
-    rpc_url: Option<Url>,
+    pub rpc_url: Option<Url>,
+
     /// The chain ID. If not provided, requires the rpc_url argument to be provided.
     #[clap(long)]
-    chain_id: Option<u64>,
+    pub chain_id: Option<u64>,
+
+    /// Optional path to the directory containing cached client input. A new cache file will be
+    /// created from RPC data if it doesn't already exist.
+    #[clap(long)]
+    pub cache_dir: Option<PathBuf>,
+
+    /// Optional path to the input file.
+    #[arg(long)]
+    pub input_path: Option<PathBuf>,
+
+    /// The number of nibbles to precompute for the preimage lookup table.
+    /// Higher values increase startup time but reduce RPC calls for missing storage keys.
+    ///
+    /// Warning: This is a form of grinding, so higher values will be slower on machines with many
+    /// CPU cores.
+    #[clap(long, default_value_t = DEFAULT_PREIMAGE_CACHE_NIBBLES, value_parser = clap::value_parser!(u8).range(..=8))]
+    pub preimage_cache_nibbles: u8,
 }
 
 pub(super) struct ProviderConfig {
@@ -19,14 +43,25 @@ pub(super) struct ProviderConfig {
     pub chain_id: u64,
 }
 
-impl ProviderArgs {
-    pub(super) async fn into_provider(self) -> eyre::Result<ProviderConfig> {
+impl RethInputSource {
+    pub fn new(block_number: u64) -> Self {
+        Self {
+            block_number: Some(block_number),
+            rpc_url: None,
+            chain_id: None,
+            cache_dir: None,
+            input_path: None,
+            preimage_cache_nibbles: DEFAULT_PREIMAGE_CACHE_NIBBLES,
+        }
+    }
+
+    pub(super) async fn resolve_provider(&self) -> eyre::Result<ProviderConfig> {
         // We don't need RPC when using cache with known chain ID, so we leave it as `Option<Url>`
         // here and decide on whether to panic later.
         //
         // On the other hand chain ID is always needed.
-        let (rpc_url, chain_id) = match (self.rpc_url, self.chain_id) {
-            (Some(rpc_url), Some(chain_id)) => (Some(rpc_url), chain_id),
+        let (rpc_url, chain_id) = match (self.rpc_url.as_ref(), self.chain_id) {
+            (Some(rpc_url), Some(chain_id)) => (Some(rpc_url.clone()), chain_id),
             (None, Some(chain_id)) => {
                 match std::env::var(format!("RPC_{chain_id}")) {
                     Ok(rpc_env_var) => {
@@ -41,10 +76,10 @@ impl ProviderArgs {
             }
             (Some(rpc_url), None) => {
                 // We can find out about chain ID from RPC.
-                let provider: RootProvider = RootProvider::new_http(rpc_url.clone());
+                let provider = RootProvider::<Ethereum>::new_http(rpc_url.clone());
                 let chain_id = provider.get_chain_id().await?;
 
-                (Some(rpc_url), chain_id)
+                (Some(rpc_url.clone()), chain_id)
             }
             (None, None) => {
                 eyre::bail!("either --rpc-url or --chain-id must be used")

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -1,6 +1,11 @@
 #![cfg_attr(feature = "tco", allow(incomplete_features))]
 #![cfg_attr(feature = "tco", feature(explicit_tail_calls))]
-use std::{fs, io::Write, path::PathBuf, time::Instant};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
@@ -11,7 +16,7 @@ use openvm_circuit::arch::{
     execution_mode::metered::segment_ctx::DEFAULT_MAX_MEMORY, instructions::exe::VmExe,
     verify_segments, VmCircuitConfig,
 };
-use openvm_rpc_proxy::{RpcExecutor, DEFAULT_PREIMAGE_CACHE_NIBBLES};
+use openvm_rpc_proxy::RpcExecutor;
 use openvm_sdk::{
     config::{
         AggregationSystemParams, AggregationTreeConfig, AppConfig, DEFAULT_APP_LOG_BLOWUP,
@@ -19,7 +24,7 @@ use openvm_sdk::{
         DEFAULT_ROOT_LOG_BLOWUP,
     },
     fs::{read_object_from_file, write_object_to_file},
-    Sdk, SC,
+    Sdk, StdIn, SC,
 };
 use openvm_sdk_config::{SdkVmConfig, TranspilerConfig};
 #[cfg(feature = "evm-verify")]
@@ -52,8 +57,10 @@ use openvm_verify_stark_host::{
 pub use reth_ethereum_primitives as reth_primitives;
 use tracing::{info, info_span};
 
+const VM_MAX_CONSTRAINT_DEGREE: usize = 4;
+
 mod cli;
-use cli::ProviderArgs;
+pub use cli::RethInputSource;
 
 /// Enum representing the execution mode of the host executable.
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -104,76 +111,6 @@ impl std::fmt::Display for BenchMode {
     }
 }
 
-/// The arguments for the host executable.
-#[derive(Debug, Parser)]
-pub struct HostArgs {
-    /// The block number of the block to execute.
-    #[clap(long)]
-    block_number: Option<u64>,
-    #[clap(flatten)]
-    provider: ProviderArgs,
-
-    /// The execution mode.
-    #[clap(long, value_enum)]
-    mode: BenchMode,
-
-    /// Optional path to the directory containing cached client input. A new cache file will be
-    /// created from RPC data if it doesn't already exist.
-    #[clap(long)]
-    cache_dir: Option<PathBuf>,
-    /// The path to the CSV file containing the execution data.
-    #[clap(long, default_value = "report.csv")]
-    report_path: PathBuf,
-    /// The path to the CSV file containing per-AIR statistics.
-    #[clap(long, default_value = "air_stats.csv")]
-    air_stats_path: PathBuf,
-
-    #[clap(flatten)]
-    benchmark: BenchmarkCli,
-
-    /// Optional path to the input file.
-    #[arg(long)]
-    pub input_path: Option<PathBuf>,
-
-    /// Path to write the fixtures to. Only needed for mode=make_input
-    #[arg(long)]
-    pub fixtures_path: Option<PathBuf>,
-
-    /// In make_input mode, this path is where the input JSON is written.
-    #[arg(long)]
-    pub generated_input_path: Option<PathBuf>,
-
-    /// If specificed, the proof and other output is written to this dir.
-    #[arg(long, default_value = "output")]
-    pub output_dir: PathBuf,
-
-    /// Optional directory used by prove-root to cache the intermediate stark proof. If set,
-    /// the stark proof is written to (or loaded from) <proof_cache>/stark.bitcode. If not
-    /// set, no proof caching is performed.
-    #[arg(long)]
-    pub proof_cache: Option<PathBuf>,
-
-    /// If specified, loads the app proving key from this path.
-    #[arg(long)]
-    pub app_pk_path: Option<PathBuf>,
-
-    /// Path to save the app verifying key (overrides output_dir)
-    #[arg(long)]
-    pub app_vk_path: Option<PathBuf>,
-
-    /// If specified, loads the agg proving key from this path.
-    #[arg(long)]
-    pub agg_pk_path: Option<PathBuf>,
-
-    /// The number of nibbles to precompute for the preimage lookup table.
-    /// Higher values increase startup time but reduce RPC calls for missing storage keys.
-    ///
-    /// Warning: This is a form of grinding, so higher values will be slower on machines with many
-    /// CPU cores.
-    #[clap(long, default_value_t = DEFAULT_PREIMAGE_CACHE_NIBBLES, value_parser = clap::value_parser!(u8).range(..=8))]
-    pub preimage_cache_nibbles: u8,
-}
-
 #[derive(Parser, Debug)]
 #[command(allow_external_subcommands = true)]
 pub struct BenchmarkCli {
@@ -205,6 +142,82 @@ pub struct BenchmarkCli {
     pub segment_max_memory: usize,
 }
 
+/// The arguments for the host executable.
+#[derive(Debug, Parser)]
+pub struct HostArgs {
+    /// The execution mode.
+    #[clap(long, value_enum)]
+    mode: BenchMode,
+
+    /// The path to the CSV file containing the execution data.
+    #[clap(long, default_value = "report.csv")]
+    report_path: PathBuf,
+    /// The path to the CSV file containing per-AIR statistics.
+    #[clap(long, default_value = "air_stats.csv")]
+    air_stats_path: PathBuf,
+
+    #[clap(flatten)]
+    benchmark: BenchmarkCli,
+
+    #[clap(flatten)]
+    input: RethInputSource,
+
+    /// Path to write the fixtures to. Only needed for mode=make_input
+    #[arg(long)]
+    pub fixtures_path: Option<PathBuf>,
+
+    /// In make_input mode, this path is where the input JSON is written.
+    #[arg(long)]
+    pub generated_input_path: Option<PathBuf>,
+
+    /// If specificed, the proof and other output is written to this dir.
+    #[arg(long, default_value = "output")]
+    pub output_dir: PathBuf,
+
+    /// Optional directory used by prove-root to cache the intermediate stark proof. If set,
+    /// the stark proof is written to (or loaded from) <proof_cache>/stark.bitcode. If not
+    /// set, no proof caching is performed.
+    #[arg(long)]
+    pub proof_cache: Option<PathBuf>,
+
+    /// If specified, loads the app proving key from this path.
+    #[arg(long)]
+    pub app_pk_path: Option<PathBuf>,
+
+    /// Path to save the app verifying key (overrides output_dir)
+    #[arg(long)]
+    pub app_vk_path: Option<PathBuf>,
+
+    /// If specified, loads the agg proving key from this path.
+    #[arg(long)]
+    pub agg_pk_path: Option<PathBuf>,
+}
+
+pub struct RethWorkload {
+    pub exe: VmExe<F>,
+    pub stdin: StdIn,
+}
+
+pub fn build_reth_workload(
+    vm_config: &SdkVmConfig,
+    stateless_input: &StatelessExecutorInput,
+    openvm_client_eth_elf: &[u8],
+) -> Result<RethWorkload> {
+    let exe = build_reth_exe(vm_config, openvm_client_eth_elf)?;
+    let encoded_stateless_input: Vec<F> = {
+        let words = openvm::serde::to_vec(stateless_input)?;
+        words.into_iter().flat_map(|w| w.to_le_bytes()).map(F::from_u8).collect()
+    };
+    let stdin = vec![encoded_stateless_input].into();
+    Ok(RethWorkload { exe, stdin })
+}
+
+pub fn build_reth_exe(vm_config: &SdkVmConfig, openvm_client_eth_elf: &[u8]) -> Result<VmExe<F>> {
+    let transpiler = vm_config.transpiler().clone();
+    let elf = Elf::decode(openvm_client_eth_elf, MEM_SIZE as u32)?;
+    Ok(VmExe::from_elf(elf, transpiler)?)
+}
+
 pub fn reth_vm_config() -> SdkVmConfig {
     let mut config = SdkVmConfig::standard();
     config.system.config = config
@@ -214,8 +227,6 @@ pub fn reth_vm_config() -> SdkVmConfig {
         .with_public_values(32);
     config
 }
-
-const VM_MAX_CONSTRAINT_DEGREE: usize = 4;
 
 fn override_system_params(
     params: SystemParams,
@@ -248,6 +259,49 @@ fn override_log_blowup(params: SystemParams, log_blowup: usize) -> Result<System
     override_system_params(params, log_blowup, l_skip)
 }
 
+pub async fn load_reth_input(source: &RethInputSource) -> Result<StatelessExecutorInput> {
+    let block_number = source
+        .block_number
+        .ok_or_else(|| eyre::eyre!("--block-number is required to load reth input"))?;
+
+    if let Some(path) = &source.input_path {
+        return try_load_input_from_path(path);
+    }
+
+    let provider_config = source.resolve_provider().await?;
+
+    match provider_config.chain_id {
+        #[allow(non_snake_case)]
+        CHAIN_ID_ETH_MAINNET => (),
+        _ => {
+            eyre::bail!("unknown chain ID: {}", provider_config.chain_id);
+        }
+    };
+
+    if let Some(stateless_input) = try_load_input_from_cache(
+        source.cache_dir.as_deref(),
+        provider_config.chain_id,
+        block_number,
+    )? {
+        return Ok(stateless_input);
+    }
+
+    let Some(rpc_url) = provider_config.rpc_url else {
+        eyre::bail!("cache not found and RPC URL not provided");
+    };
+
+    let client = RpcClient::builder().layer(RetryBackoffLayer::new(5, 1000, 100)).http(rpc_url);
+    let provider = RootProvider::new(client);
+    let rpc_executor = RpcExecutor::new(provider, source.preimage_cache_nibbles);
+    let stateless_input = rpc_executor.execute(block_number).await?;
+
+    if let Some(cache_dir) = &source.cache_dir {
+        write_input_to_cache(cache_dir, provider_config.chain_id, block_number, &stateless_input)?;
+    }
+
+    Ok(stateless_input)
+}
+
 pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) -> Result<()> {
     // Initialize the environment variables.
     dotenv::dotenv().ok();
@@ -262,8 +316,6 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         tracing::debug!("air_idx={air_idx} | {}", air.name());
     }
 
-    let transpiler = vm_config.transpiler().clone();
-
     let app_params = override_system_params(
         app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT),
         args.benchmark.app_log_blowup,
@@ -271,7 +323,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     )?;
 
     // Setup: this can all be done once before receiving proof input
-    let app_config = AppConfig::new(vm_config, app_params);
+    let app_config = AppConfig::new(vm_config.clone(), app_params);
     let agg_params = AggregationSystemParams {
         leaf: override_log_blowup(
             leaf_params_with_100_bits_security(),
@@ -335,10 +387,8 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         return Ok(());
     }
 
-    let elf = Elf::decode(openvm_client_eth_elf, MEM_SIZE as u32)?;
-    let exe = VmExe::from_elf(elf, transpiler)?;
-
     if matches!(args.mode, BenchMode::GenerateVmVkey) {
+        let exe = build_reth_exe(&vm_config, openvm_client_eth_elf)?;
         let prover = sdk.prover(exe)?;
         let vk = VmStarkVerifyingKey {
             mvk: (*sdk.agg_vk()).clone(),
@@ -351,72 +401,13 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     }
 
     let block_number = args
+        .input
         .block_number
         .ok_or_else(|| eyre::eyre!("--block-number is required for mode {}", args.mode))?;
 
     let program_name = format!("reth.{}.block_{}", args.mode, block_number);
 
-    // Parse the command line arguments.
-    let stateless_input_from_path =
-        args.input_path.as_ref().map(|path| try_load_input_from_path(path).unwrap());
-
-    let stateless_input = if let Some(stateless_input_from_path) = stateless_input_from_path {
-        stateless_input_from_path
-    } else {
-        let provider_config = args.provider.into_provider().await?;
-        match provider_config.chain_id {
-            #[allow(non_snake_case)]
-            CHAIN_ID_ETH_MAINNET => (),
-            _ => {
-                eyre::bail!("unknown chain ID: {}", provider_config.chain_id);
-            }
-        };
-        let stateless_input_from_cache = try_load_input_from_cache(
-            args.cache_dir.as_ref(),
-            provider_config.chain_id,
-            block_number,
-        )?;
-
-        match (stateless_input_from_cache, provider_config.rpc_url) {
-            (Some(stateless_input_from_cache), _) => stateless_input_from_cache,
-            (None, Some(rpc_url)) => {
-                // Cache not found but we have RPC
-                // Setup the provider.
-                let client =
-                    RpcClient::builder().layer(RetryBackoffLayer::new(5, 1000, 100)).http(rpc_url);
-                let provider = RootProvider::new(client);
-
-                // Setup the host executor.
-                let rpc_executor = RpcExecutor::new(provider, args.preimage_cache_nibbles);
-
-                // Execute the host.
-                let stateless_input =
-                    rpc_executor.execute(block_number).await.expect("failed to execute host");
-
-                if let Some(cache_dir) = args.cache_dir {
-                    let input_folder =
-                        cache_dir.join(format!("input/{}", provider_config.chain_id));
-                    if !input_folder.exists() {
-                        std::fs::create_dir_all(&input_folder)?;
-                    }
-
-                    let input_path = input_folder.join(format!("{}.bin", block_number));
-                    let mut cache_file = std::fs::File::create(input_path)?;
-
-                    bincode::serde::encode_into_std_write(
-                        &stateless_input,
-                        &mut cache_file,
-                        bincode::config::standard(),
-                    )?;
-                }
-
-                stateless_input
-            }
-            (None, None) => {
-                eyre::bail!("cache not found and RPC URL not provided")
-            }
-        }
-    };
+    let stateless_input = load_reth_input(&args.input).await?;
 
     // MakeInput: encode stateless_input as JSON and write to disk.
     if matches!(args.mode, BenchMode::MakeInput) {
@@ -439,7 +430,6 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     // Host execution: run the stateless executor natively, no VM.
     if matches!(args.mode, BenchMode::ExecuteHost) {
-        let program_name = format!("reth.{}.block_{}", args.mode, block_number);
         let executor = StatelessExecutor;
         let start = Instant::now();
         let header = info_span!("host.execute", group = program_name).in_scope(|| {
@@ -454,27 +444,22 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         return Ok(());
     }
 
-    let encoded_stateless_input: Vec<F> = {
-        let words = openvm::serde::to_vec(&stateless_input)?;
-        words.into_iter().flat_map(|w| w.to_le_bytes()).map(F::from_u8).collect()
-    };
-
-    let stdin = vec![encoded_stateless_input].into();
+    let RethWorkload { exe, stdin } =
+        build_reth_workload(&vm_config, &stateless_input, openvm_client_eth_elf)?;
 
     run_with_metric_collection("OUTPUT_PATH", move || {
         info_span!("reth-block", block_number = block_number).in_scope(|| -> Result<()> {
             match args.mode {
                 BenchMode::Execute => {
-                    let public_values = info_span!("sdk.compile_and_execute", group = program_name)
-                        .in_scope(|| sdk.compile_and_execute(exe, stdin))?;
+                    let compiled = sdk.compile(exe)?;
+                    let public_values = sdk.execute(&compiled, stdin)?;
                     let block_hash = hex::encode(&public_values);
                     info!("Execute completed, block hash: {}", block_hash);
                     println!("BENCH_BLOCK_HASH={block_hash}");
                 }
                 BenchMode::ExecuteMetered => {
-                    let (public_values, _) =
-                        info_span!("sdk.compile_and_execute_metered", group = program_name)
-                            .in_scope(|| sdk.compile_and_execute_metered(exe, stdin))?;
+                    let compiled = sdk.compile_metered(exe)?;
+                    let (public_values, _) = sdk.execute_metered(&compiled, stdin)?;
                     let block_hash = hex::encode(&public_values);
                     info!("Execute metered completed, block hash: {}", block_hash);
                     println!("BENCH_BLOCK_HASH={block_hash}");
@@ -700,7 +685,7 @@ fn max_rule_length<F>(dag: &SymbolicExpressionDag<F>) -> usize {
 }
 
 fn try_load_input_from_cache(
-    cache_dir: Option<&PathBuf>,
+    cache_dir: Option<&Path>,
     chain_id: u64,
     block_number: u64,
 ) -> Result<Option<StatelessExecutorInput>> {
@@ -722,7 +707,26 @@ fn try_load_input_from_cache(
     })
 }
 
-fn try_load_input_from_path(path: &PathBuf) -> Result<StatelessExecutorInput> {
+fn write_input_to_cache(
+    cache_dir: &Path,
+    chain_id: u64,
+    block_number: u64,
+    stateless_input: &StatelessExecutorInput,
+) -> Result<()> {
+    let input_folder = cache_dir.join(format!("input/{chain_id}"));
+    fs::create_dir_all(&input_folder)?;
+
+    let input_path = input_folder.join(format!("{block_number}.bin"));
+    let mut cache_file = fs::File::create(input_path)?;
+    bincode::serde::encode_into_std_write(
+        stateless_input,
+        &mut cache_file,
+        bincode::config::standard(),
+    )?;
+    Ok(())
+}
+
+fn try_load_input_from_path(path: &Path) -> Result<StatelessExecutorInput> {
     let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
     if ext.eq_ignore_ascii_case("json") {
         let s = std::fs::read_to_string(path)?;


### PR DESCRIPTION
## Summary

This exposes the Reth benchmark workload construction path so downstream harnesses can reuse `openvm-reth-benchmark` as a library instead of duplicating the CLI flow.

- Adds reusable helpers for loading Reth input, building the Reth `VmExe`, and constructing the OpenVM stdin/workload.
- Reuses the existing CLI input/provider parsing shape through `RethInputSource`, so the binary path keeps the same flags and behavior.
- Keeps the change scoped to the benchmark API surface needed by external consumers

## Testing

- `env RUSTC_WRAPPER= cargo check -p openvm-reth-benchmark --no-default-features --features parallel,metrics,jemalloc,unprotected`
- `env RUSTC_WRAPPER= cargo check -p openvm-reth-benchmark --no-default-features --features parallel,metrics,jemalloc,unprotected,rvr`
