### PR TITLE
ci: fix compare-results metrics path

### DIFF
--- a/.github/workflows/compare-branches.yml
+++ b/.github/workflows/compare-branches.yml
@@ -130,11 +130,10 @@ jobs:
 
       - name: Compare metrics
         run: |
-          ls
           BASE_NAME=${{ needs.run-base-benchmark.outputs.metric_name }}
-          BASE_JSON=$BASE_NAME/metrics.json
+          BASE_JSON=$BASE_NAME/$BASE_NAME.json
           TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}
-          TARGET_JSON=$TARGET_NAME/metrics.json
+          TARGET_JSON=$TARGET_NAME/$TARGET_NAME.json
 
           openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON
           MD_PATH=${TARGET_JSON%.json}.md


### PR DESCRIPTION
The `compare-results` job of **Compare Branches** has been failing on every run with `No such file or directory` (at `openvm-prof`'s `prof/src/lib.rs:19`), so the workflow never produced a comparison table — the two benchmark jobs succeed and upload usable artifacts, but the aggregation step dies.

**Cause:** each benchmark artifact stores its metrics as `<metric_name>/<metric_name>.json` (plus `.detailed.md`), but the compare step read `<metric_name>/metrics.json`, which doesn't exist.

**Fix:** point `BASE_JSON`/`TARGET_JSON` at `$NAME/$NAME.json`. `MD_PATH` (derived via `${TARGET_JSON%.json}.md`) stays consistent with what `openvm-prof` emits. Also drops a leftover `ls` debug line.

Verified against run 27964893915: downloading those artifacts and pointing `openvm-prof` at `<name>/<name>.json` is exactly the recovery used to produce the comparison in #630.
