### PR TITLE
fix: update revm crypto sha256 and modexp

### DIFF
--- a/.github/workflows/tests-revm-crypto.yml
+++ b/.github/workflows/tests-revm-crypto.yml
@@ -1,0 +1,38 @@
+name: OpenVM REVM Crypto Tests
+
+on:
+  pull_request:
+    paths:
+      - "crates/revm-crypto/**"
+      - "crates/kzg/**"
+      - "crates/curve-utils/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/tests-revm-crypto.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  test:
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=64cpu-linux-arm64
+      - extras=s3-cache
+
+    steps:
+      - uses: runs-on/action@v2
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@nextest
+
+      - name: Run tests
+        run: cargo nextest run -p openvm-revm-crypto

--- a/crates/revm-crypto/Cargo.toml
+++ b/crates/revm-crypto/Cargo.toml
@@ -20,7 +20,7 @@ alloy-consensus = { workspace = true, features = ["crypto-backend"] }
 # OpenVM dependencies for optimized crypto (only needed when running in zkvm)
 openvm-curve-utils = { workspace = true, features = ["bn254", "bls12_381"] }
 openvm-ecc-guest = { workspace = true }
-openvm-sha2 = { workspace = true }
+openvm-sha2 = { workspace = true, features = ["import_sha2"] }
 openvm-pairing = { workspace = true, features = ["bn254", "bls12_381"] }
 openvm-k256 = { workspace = true }
 openvm-p256 = { workspace = true }
@@ -40,5 +40,4 @@ revm-primitives = { workspace = true, features = ["hashbrown"] }
 alloy-primitives = { workspace = true, features = ["native-keccak"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-openvm-sha2 = { workspace = true, features = ["import_sha2"] }
 openvm-keccak256 = { workspace = true, features = ["tiny_keccak"] }

--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -16,7 +16,6 @@ use openvm_ecc_guest::{
 use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
 use openvm_keccak256::keccak256;
 use openvm_kzg::{Bytes32, Bytes48, KzgProof};
-use openvm_sha2::Digest;
 #[allow(unused_imports, clippy::single_component_path_imports)]
 use openvm_p256; // ensure this is linked in for the standard OpenVM config
 use openvm_pairing::{
@@ -24,6 +23,7 @@ use openvm_pairing::{
     bn254::{self as bn, Bn254},
     PairingCheck,
 };
+use openvm_sha2::Digest;
 use revm::{
     install_crypto,
     precompile::{
@@ -84,7 +84,7 @@ impl CryptoProvider for OpenVmK256Provider {
         let encoded_pubkey = &public_key.as_bytes()[1..65];
 
         // Hash to get Ethereum address
-        let pubkey_hash = keccak256(&encoded_pubkey);
+        let pubkey_hash = keccak256(encoded_pubkey);
         let address_bytes = &pubkey_hash[12..32]; // Last 20 bytes
 
         Ok(Address::from_slice(address_bytes))
@@ -288,7 +288,7 @@ impl Crypto for OpenVmCrypto {
         let public_key = recovered_key.to_encoded_point(false);
         let encoded_pubkey = &public_key.as_bytes()[1..65];
 
-        let pubkey_hash = keccak256(&encoded_pubkey);
+        let pubkey_hash = keccak256(encoded_pubkey);
         let mut address = [0u8; 32];
         address[12..].copy_from_slice(&pubkey_hash[12..]);
 

--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -16,6 +16,7 @@ use openvm_ecc_guest::{
 use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
 use openvm_keccak256::keccak256;
 use openvm_kzg::{Bytes32, Bytes48, KzgProof};
+use openvm_sha2::Digest;
 #[allow(unused_imports, clippy::single_component_path_imports)]
 use openvm_p256; // ensure this is linked in for the standard OpenVM config
 use openvm_pairing::{
@@ -117,8 +118,6 @@ struct OpenVmCrypto;
 impl Crypto for OpenVmCrypto {
     /// Custom SHA-256 implementation with openvm optimization
     fn sha256(&self, input: &[u8]) -> [u8; 32] {
-        #[cfg(not(target_os = "zkvm"))]
-        use openvm_sha2::Digest;
         openvm_sha2::Sha256::digest(input).into()
     }
 
@@ -351,16 +350,11 @@ fn is_bn254_fr(modulus: &[u8]) -> bool {
 fn accelerated_modexp_bn254_fr(base: &[u8], exp: &[u8]) -> Vec<u8> {
     use openvm_ecc_guest::algebra::{ExpBytes, Reduce};
 
-    let base_fr = if base.len() <= BN_SCALAR_LEN {
-        // Use checked conversion; reduce if base >= modulus.
-        bn::Scalar::from_be_bytes(base).unwrap_or_else(|| bn::Scalar::reduce_be_bytes(base))
-    } else {
-        // Pad to a multiple of BN_SCALAR_LEN so reduce_be_bytes chunk processing works correctly.
-        let padded_len = base.len().next_multiple_of(BN_SCALAR_LEN);
-        let mut padded = vec![0u8; padded_len];
-        padded[padded_len - base.len()..].copy_from_slice(base);
-        bn::Scalar::reduce_be_bytes(&padded)
-    };
+    // OpenVM's field reduction requires inputs to be aligned to the field byte size.
+    let padded_len = base.len().next_multiple_of(BN_SCALAR_LEN).max(BN_SCALAR_LEN);
+    let mut padded = vec![0u8; padded_len];
+    padded[padded_len - base.len()..].copy_from_slice(base);
+    let base_fr = bn::Scalar::reduce_be_bytes(&padded);
 
     base_fr.exp_bytes(true, exp).to_be_bytes().as_ref().to_vec()
 }


### PR DESCRIPTION
- Make the SHA-256 setup explicit so this crate builds the same way across targets.
- Pad modexp inputs before reducing them to match OpenVM's current input-size requirement.
- Add a PR check for the `openvm-revm-crypto` tests.