### PR TITLE
fix: revm crypto

### DIFF
--- a/crates/kzg/src/kzg_proof.rs
+++ b/crates/kzg/src/kzg_proof.rs
@@ -226,6 +226,9 @@ pub fn safe_g1_affine_from_bytes(bytes: &Bytes48) -> Result<Bls12_381G1Affine, K
     if infinity_flag_set && compression_flag_set && !sort_flag_set && x == Fp::ZERO {
         return Ok(<Bls12_381G1Affine as Group>::IDENTITY);
     }
+    if infinity_flag_set || !compression_flag_set {
+        return Err(KzgError::BadArgs("invalid G1 point encoding".to_string()));
+    }
 
     // Note that we need to determine the y-coord using lexicographic ordering instead of parity, so
     // the value for rec_id does not matter and we can pass in either 0 or 1.

--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -173,8 +173,9 @@ impl Crypto for OpenVmCrypto {
         a: BlsG1Point,
         b: BlsG1Point,
     ) -> Result<[u8; BLS_G1_LEN], PrecompileHalt> {
-        let p1 = read_bls_g1_point(&a)?;
-        let p2 = read_bls_g1_point(&b)?;
+        // EIP-2537 G1ADD validates on-curve only, not subgroup membership.
+        let p1 = read_bls_g1_point_no_subgroup_check(&a)?;
+        let p2 = read_bls_g1_point_no_subgroup_check(&b)?;
         let sum = p1 + p2;
         Ok(encode_bls_g1_point(&sum))
     }
@@ -207,8 +208,9 @@ impl Crypto for OpenVmCrypto {
         a: BlsG2Point,
         b: BlsG2Point,
     ) -> Result<[u8; BLS_G2_LEN], PrecompileHalt> {
-        let p1 = read_bls_g2_point(&a)?;
-        let p2 = read_bls_g2_point(&b)?;
+        // EIP-2537 G2ADD validates on-curve only, not subgroup membership.
+        let p1 = read_bls_g2_point_no_subgroup_check(&a)?;
+        let p2 = read_bls_g2_point_no_subgroup_check(&b)?;
         let sum = p1 + p2;
         Ok(encode_bls_g2_point(&sum))
     }
@@ -315,7 +317,7 @@ impl Crypto for OpenVmCrypto {
         let proof_bytes =
             Bytes48::from_slice(proof).map_err(|_| PrecompileHalt::other("invalid proof bytes"))?;
 
-        KzgProof::verify_kzg_proof(
+        let valid = KzgProof::verify_kzg_proof(
             &commitment_bytes,
             &z_bytes,
             &y_bytes,
@@ -323,7 +325,11 @@ impl Crypto for OpenVmCrypto {
             kzg_settings,
         )
         .map_err(|_| PrecompileHalt::other("openvm kzg proof verification failed"))?;
-        Ok(())
+        if valid {
+            Ok(())
+        } else {
+            Err(PrecompileHalt::BlobVerifyKzgProofFailed)
+        }
     }
 
     /// Custom modular exponentiation with BN254 Fr acceleration
@@ -474,13 +480,19 @@ fn read_bls_fp2(c0: &[u8], c1: &[u8]) -> Result<bls::Fp2, PrecompileHalt> {
 }
 
 #[inline]
-fn read_bls_g1_point(point: &BlsG1Point) -> Result<bls::G1Affine, PrecompileHalt> {
+fn read_bls_g1_point_no_subgroup_check(
+    point: &BlsG1Point,
+) -> Result<bls::G1Affine, PrecompileHalt> {
     let px = read_bls_fp(&point.0)?;
     let py = read_bls_fp(&point.1)?;
     // SAFETY: `read_bls_fp` produces canonical Fp elements; `from_xy` itself checks the curve
     // equation and returns `None` if `(px, py)` is not on the curve.
-    let point =
-        unsafe { bls::G1Affine::from_xy(px, py) }.ok_or(PrecompileHalt::Bls12381G1NotOnCurve)?;
+    unsafe { bls::G1Affine::from_xy(px, py) }.ok_or(PrecompileHalt::Bls12381G1NotOnCurve)
+}
+
+#[inline]
+fn read_bls_g1_point(point: &BlsG1Point) -> Result<bls::G1Affine, PrecompileHalt> {
+    let point = read_bls_g1_point_no_subgroup_check(point)?;
     if point.is_in_correct_subgroup() {
         Ok(point)
     } else {
@@ -489,13 +501,19 @@ fn read_bls_g1_point(point: &BlsG1Point) -> Result<bls::G1Affine, PrecompileHalt
 }
 
 #[inline]
-fn read_bls_g2_point(point: &BlsG2Point) -> Result<bls::G2Affine, PrecompileHalt> {
+fn read_bls_g2_point_no_subgroup_check(
+    point: &BlsG2Point,
+) -> Result<bls::G2Affine, PrecompileHalt> {
     let x = read_bls_fp2(&point.0, &point.1)?;
     let y = read_bls_fp2(&point.2, &point.3)?;
     // SAFETY: `read_bls_fp2` produces canonical Fp2 elements; `from_xy` itself checks the curve
     // equation and returns `None` if `(x, y)` is not on the twist.
-    let point =
-        unsafe { bls::G2Affine::from_xy(x, y) }.ok_or(PrecompileHalt::Bls12381G2NotOnCurve)?;
+    unsafe { bls::G2Affine::from_xy(x, y) }.ok_or(PrecompileHalt::Bls12381G2NotOnCurve)
+}
+
+#[inline]
+fn read_bls_g2_point(point: &BlsG2Point) -> Result<bls::G2Affine, PrecompileHalt> {
+    let point = read_bls_g2_point_no_subgroup_check(point)?;
     if point.is_in_correct_subgroup() {
         Ok(point)
     } else {

--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -16,8 +16,6 @@ use openvm_ecc_guest::{
 use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
 use openvm_keccak256::keccak256;
 use openvm_kzg::{Bytes32, Bytes48, KzgProof};
-#[allow(unused_imports, clippy::single_component_path_imports)]
-use openvm_p256; // ensure this is linked in for the standard OpenVM config
 use openvm_pairing::{
     bls12_381::{self as bls, Bls12_381},
     bn254::{self as bn, Bn254},
@@ -295,6 +293,27 @@ impl Crypto for OpenVmCrypto {
         address[12..].copy_from_slice(&pubkey_hash[12..]);
 
         Ok(address)
+    }
+
+    /// Custom secp256r1 signature verification with openvm optimization
+    fn secp256r1_verify_signature(&self, msg: &[u8; 32], sig: &[u8; 64], pk: &[u8; 64]) -> bool {
+        use openvm_p256::{
+            ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey},
+            EncodedPoint,
+        };
+
+        // Can fail only if the input is not exact length.
+        let Ok(signature) = Signature::from_slice(sig) else {
+            return false;
+        };
+        // Decode the public key bytes (x,y coordinates) using EncodedPoint
+        let encoded_point = EncodedPoint::from_untagged_bytes(&(*pk).into());
+        // Create VerifyingKey from the encoded point
+        let Ok(public_key) = VerifyingKey::from_encoded_point(&encoded_point) else {
+            return false;
+        };
+
+        public_key.verify_prehash(msg, &signature).is_ok()
     }
 
     /// Custom KZG point evaluation with configurable backends


### PR DESCRIPTION
1. Fix `bls12_381_g1_add` and `bls12_381_g2_add` to skip subgroup check (see the note in [here](https://eips.ethereum.org/EIPS/eip-2537#abi-for-g1-addition) and [here](https://eips.ethereum.org/EIPS/eip-2537#abi-for-g2-addition))
2. Fix `verify_kzg_proof` to return `Err(PrecompileHalt::BlobVerifyKzgProofFailed)` if the bool returned by `KzgProof::verify_kzg_proof` is `false`, also fix `safe_g1_affine_from_bytes` of zkvm impl (conform to spec and also consistent with host impl).
3. Implement `secp256r1_verify_signature` by `openvm_p256` (not sure whether it is left unimplemented intentionally or not tho)

Verified against the test suites of [`execution-specs@tests-zkevm@v0.4.1`](https://github.com/ethereum/execution-specs/releases/tag/tests-zkevm%40v0.4.1) (23264 fixtures).