### PR TITLE
fix: proper lifetimes for `EthereumState`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7479,6 +7479,7 @@ version = "0.4.0"
 dependencies = [
  "alloy-provider",
  "bincode 2.0.1",
+ "bumpalo",
  "criterion",
  "dhat",
  "dotenv",
@@ -8087,6 +8088,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-rlp",
  "alloy-rpc-types-debug",
+ "bumpalo",
  "itertools 0.14.0",
  "metrics 0.24.6",
  "openvm-mpt",

--- a/crates/mpt-tools/Cargo.toml
+++ b/crates/mpt-tools/Cargo.toml
@@ -16,6 +16,7 @@ tokio.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 dotenv = "0.15.0"
 bincode = { workspace = true, features = ["serde", "std"] }
+bumpalo.workspace = true
 
 # Memory profiling
 dhat = "0.3"

--- a/crates/mpt-tools/benches/mpt_performance.rs
+++ b/crates/mpt-tools/benches/mpt_performance.rs
@@ -1,7 +1,11 @@
 use bincode::config::standard;
+use bumpalo::Bump;
 use criterion::{criterion_group, criterion_main, Criterion};
 use openvm_chainspec::mainnet;
-use openvm_stateless_executor::io::{StatelessExecutorInput, StatelessExecutorInputWithState};
+use openvm_stateless_executor::{
+    io::{StatelessExecutorInput, StatelessExecutorInputWithState},
+    BUMP_AREA_SIZE,
+};
 use reth_evm::execute::{BasicBlockExecutor, Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_types::ExecutionOutcome;
@@ -26,7 +30,8 @@ fn benchmark_mpt_operations(c: &mut Criterion) {
     // Pre-compute the post-state once for the MPT benchmarks (not timed)
     let (pre_input, _): (StatelessExecutorInput, _) =
         bincode::serde::decode_from_slice(&buffer, bincode_config).unwrap();
-    let stateless_input = StatelessExecutorInputWithState::build(pre_input.clone()).unwrap();
+    let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+    let stateless_input = StatelessExecutorInputWithState::build(&pre_input, &bump).unwrap();
     let witness_db = stateless_input.witness_db().unwrap();
     let cache_db = CacheDB::new(&witness_db);
     let spec = Arc::new(mainnet());
@@ -48,8 +53,9 @@ fn benchmark_mpt_operations(c: &mut Criterion) {
             let (pre_input, _): (StatelessExecutorInput, _) =
                 bincode::serde::decode_from_slice(black_box(&buffer), bincode_config).unwrap();
 
+            let bump = Bump::with_capacity(BUMP_AREA_SIZE);
             let mut stateless_input =
-                StatelessExecutorInputWithState::build(pre_input.clone()).unwrap();
+                StatelessExecutorInputWithState::build(&pre_input, &bump).unwrap();
 
             // Create witness DB (this happens in production)
             let _witness_db = stateless_input.witness_db().unwrap();
@@ -73,8 +79,9 @@ fn benchmark_mpt_operations(c: &mut Criterion) {
 
     c.bench_function("resolve only", |b| {
         b.iter(|| {
-            let stateless_input = StatelessExecutorInputWithState::build(pre_input.clone());
-            black_box(stateless_input)
+            let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+            let stateless_input = StatelessExecutorInputWithState::build(&pre_input, &bump);
+            black_box(&stateless_input);
         })
     });
 

--- a/crates/mpt-tools/src/bin/mpt_profiler.rs
+++ b/crates/mpt-tools/src/bin/mpt_profiler.rs
@@ -2,10 +2,14 @@
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use bincode::config::standard;
+use bumpalo::Bump;
 use dhat::Profiler;
 use openvm_chainspec::mainnet;
 use openvm_mpt::EthereumState;
-use openvm_stateless_executor::io::{StatelessExecutorInput, StatelessExecutorInputWithState};
+use openvm_stateless_executor::{
+    io::{StatelessExecutorInput, StatelessExecutorInputWithState},
+    BUMP_AREA_SIZE,
+};
 use reth_evm::execute::{BasicBlockExecutor, Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_types::ExecutionOutcome;
@@ -50,7 +54,8 @@ fn main() {
     // Pre-compute the post-state once
     let (pre_input, _): (StatelessExecutorInput, _) =
         bincode::serde::decode_from_slice(&buffer, bincode_config).unwrap();
-    let stateless_input = StatelessExecutorInputWithState::build(pre_input.clone()).unwrap();
+    let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+    let stateless_input = StatelessExecutorInputWithState::build(&pre_input, &bump).unwrap();
     let witness_db = stateless_input.witness_db().unwrap();
     let cache_db = CacheDB::new(&witness_db);
     let spec = Arc::new(mainnet());
@@ -77,7 +82,7 @@ fn main() {
         }
         "witness" => {
             println!("Profiling: Witness DB creation only");
-            profile_witness_db(pre_input);
+            profile_witness_db(pre_input.clone());
         }
         "update" => {
             println!("Profiling: MPT update only");
@@ -105,7 +110,8 @@ fn profile_end_to_end(buffer: &[u8], executor_outcome: &ExecutionOutcome) {
     let (pre_input, _): (StatelessExecutorInput, _) =
         bincode::serde::decode_from_slice(buffer, bincode_config).unwrap();
 
-    let mut stateless_input = StatelessExecutorInputWithState::build(pre_input).unwrap();
+    let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+    let mut stateless_input = StatelessExecutorInputWithState::build(&pre_input, &bump).unwrap();
 
     // Create witness DB
     let _witness_db = stateless_input.witness_db().unwrap();
@@ -126,18 +132,19 @@ fn profile_deserialize(buffer: &[u8]) {
 fn profile_witness_db(stateless_input: StatelessExecutorInput) {
     let _profiler = Profiler::new_heap();
 
-    let input = StatelessExecutorInputWithState::build(stateless_input).unwrap();
+    let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+    let input = StatelessExecutorInputWithState::build(&stateless_input, &bump).unwrap();
 
     let _witness_db = input.witness_db().unwrap();
 }
 
-fn profile_update(mut parent_state: EthereumState, executor_outcome: &ExecutionOutcome) {
+fn profile_update(mut parent_state: EthereumState<'_>, executor_outcome: &ExecutionOutcome) {
     let _profiler = Profiler::new_heap();
 
     parent_state.update_from_bundle_state(&executor_outcome.bundle).unwrap();
 }
 
-fn profile_state_root(mut parent_state: EthereumState, executor_outcome: &ExecutionOutcome) {
+fn profile_state_root(mut parent_state: EthereumState<'_>, executor_outcome: &ExecutionOutcome) {
     let _profiler = Profiler::new_heap();
 
     parent_state.update_from_bundle_state(&executor_outcome.bundle).unwrap();

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -1,9 +1,10 @@
 use crate::{
     node::{NodeData, NodeId},
-    trie::{owned::MptOwned, NULL_NODE_ID, NULL_NODE_REF_SLICE},
+    trie::{NULL_NODE_ID, NULL_NODE_REF_SLICE},
     Error, Mpt,
 };
 use alloy_rlp::PayloadView;
+use bumpalo::Bump;
 use bytes::{BufMut, BytesMut};
 use revm_primitives::{Bytes, HashMap, B256};
 
@@ -25,9 +26,10 @@ impl MptResolver {
         MptResolver { node_store }
     }
 
-    /// Resolves an MPT from the mapping stored in [`MptResolver`] given its `root` hash.
-    pub fn resolve(&self, root: &B256) -> Result<Mpt<'static>, Error> {
-        let mut mpt = MptOwned::default();
+    /// Resolves an MPT from the mapping stored in [`MptResolver`] given its `root` hash. All node
+    /// data is copied into `bump`.
+    pub fn resolve<'a>(&self, bump: &'a Bump, root: &B256) -> Result<Mpt<'a>, Error> {
+        let mut mpt = Mpt::new(bump);
 
         let rlp_root = {
             let mut out = BytesMut::with_capacity(33);
@@ -39,14 +41,10 @@ impl MptResolver {
         let root_id = self.resolve_internal(&mut rlp_root.as_slice(), &mut mpt)?;
         mpt.set_root_id(root_id);
 
-        Ok(mpt.into_inner())
+        Ok(mpt)
     }
 
-    fn resolve_internal(
-        &self,
-        node_bytes: &mut &[u8],
-        mpt: &mut MptOwned,
-    ) -> Result<NodeId, Error> {
+    fn resolve_internal(&self, node_bytes: &mut &[u8], mpt: &mut Mpt<'_>) -> Result<NodeId, Error> {
         let node_id = match alloy_rlp::Header::decode_raw(node_bytes)? {
             PayloadView::String(item) => match item.len() {
                 0 => NULL_NODE_ID,
@@ -54,7 +52,7 @@ impl MptResolver {
                     Some(resolved_node_bytes) => {
                         self.resolve_internal(&mut resolved_node_bytes.as_ref(), mpt)?
                     }
-                    None => mpt.add_node(&NodeData::Digest(item)),
+                    None => mpt.add_node_copied(&NodeData::Digest(item)),
                 },
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));
@@ -67,11 +65,11 @@ impl MptResolver {
                     if (prefix & (2 << 4)) == 0 {
                         let ext_node_id = self.resolve_internal(&mut items[1], mpt)?;
                         let node_data = NodeData::Extension(path, ext_node_id);
-                        mpt.add_node(&node_data)
+                        mpt.add_node_copied(&node_data)
                     } else {
                         let value = alloy_rlp::Header::decode_bytes(&mut items[1], false)?;
                         let node_data = NodeData::Leaf(path, value);
-                        mpt.add_node(&node_data)
+                        mpt.add_node_copied(&node_data)
                     }
                 }
                 17 => {
@@ -85,7 +83,7 @@ impl MptResolver {
                         childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
                     }
                     let node_data = NodeData::Branch(childs);
-                    mpt.add_node(&node_data)
+                    mpt.add_node_copied(&node_data)
                 }
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));
@@ -121,7 +119,8 @@ mod tests {
         }
 
         let mpt_resolver = MptResolver::from_iter(node_store);
-        let resolved_trie = mpt_resolver.resolve(&trie.hash())?;
+        let resolve_bump = bumpalo::Bump::new();
+        let resolved_trie = mpt_resolver.resolve(&resolve_bump, &trie.hash())?;
 
         assert_eq!(resolved_trie.hash(), trie.hash());
 

--- a/crates/mpt/src/state.rs
+++ b/crates/mpt/src/state.rs
@@ -13,15 +13,15 @@ pub struct EthereumStateBytes {
 }
 
 #[derive(Debug, Clone)]
-pub struct EthereumState {
-    pub state_trie: Mpt<'static>,
-    pub storage_tries: HashMap<B256, Mpt<'static>>,
-    pub bump: &'static Bump,
+pub struct EthereumState<'a> {
+    pub state_trie: Mpt<'a>,
+    pub storage_tries: HashMap<B256, Mpt<'a>>,
+    pub bump: &'a Bump,
 }
 
-impl EthereumState {
-    pub fn new() -> Self {
-        let bump = Box::leak(Box::new(Bump::new()));
+impl<'a> EthereumState<'a> {
+    /// Creates an empty state whose tries allocate from `bump`.
+    pub fn new_in(bump: &'a Bump) -> Self {
         Self {
             state_trie: Mpt::new(bump),
             storage_tries: HashMap::with_capacity_and_hasher(1, DefaultHashBuilder::default()),
@@ -29,15 +29,14 @@ impl EthereumState {
         }
     }
 
+    /// Creates a state from existing tries. `bump` is used for allocations made by future
+    /// updates; the tries must allocate from a bump that lives at least as long as it.
     pub fn from_tries(
-        state_trie: Mpt<'static>,
-        storage_tries: impl IntoIterator<Item = (B256, Mpt<'static>)>,
+        state_trie: Mpt<'a>,
+        storage_tries: impl IntoIterator<Item = (B256, Mpt<'a>)>,
+        bump: &'a Bump,
     ) -> Self {
-        Self {
-            state_trie,
-            storage_tries: storage_tries.into_iter().collect(),
-            bump: Box::leak(Box::new(Bump::new())),
-        }
+        Self { state_trie, storage_tries: storage_tries.into_iter().collect(), bump }
     }
 
     pub fn update_from_bundle_state(&mut self, bundle_state: &BundleState) -> Result<(), Error> {
@@ -107,11 +106,5 @@ impl EthereumState {
             state_trie: (state_num_nodes, state_bytes),
             storage_tries: storage_bytes,
         }
-    }
-}
-
-impl Default for EthereumState {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -575,11 +575,31 @@ impl<'a> Mpt<'a> {
         id
     }
 
-    /// Sets the root node ID. Used for testing to construct tries with specific structure.
-    #[cfg(test)]
+    /// Sets the root node ID. Used by the resolver and by tests to construct tries with specific
+    /// structure.
+    #[cfg(any(test, feature = "host"))]
     #[inline]
     pub(crate) fn set_root_id(&mut self, root_id: NodeId) {
         self.root_id = root_id;
+    }
+
+    /// Adds a new node to the trie, copying any borrowed slices into the trie's bump arena, and
+    /// returns the new node's ID.
+    #[cfg(feature = "host")]
+    pub(crate) fn add_node_copied(&mut self, data: &NodeData<'_>) -> NodeId {
+        let data = match data {
+            NodeData::Null => NodeData::Null,
+            NodeData::Branch(childs) => NodeData::Branch(*childs),
+            NodeData::Leaf(prefix, value) => NodeData::Leaf(
+                self.bump.alloc_slice_copy(prefix),
+                self.bump.alloc_slice_copy(value),
+            ),
+            NodeData::Extension(prefix, ext_node_id) => {
+                NodeData::Extension(self.bump.alloc_slice_copy(prefix), *ext_node_id)
+            }
+            NodeData::Digest(digest) => NodeData::Digest(self.bump.alloc_slice_copy(digest)),
+        };
+        self.add_node(data, None)
     }
 
     #[inline]
@@ -999,124 +1019,6 @@ impl Mpt<'_> {
             NodeData::Digest(digest) => {
                 println!("{}Digest {:?}", indent, B256::from_slice(digest));
             }
-        }
-    }
-}
-
-#[cfg(feature = "host")]
-pub(crate) mod owned {
-    use bumpalo::Bump;
-    use revm_primitives::B256;
-
-    use crate::{
-        node::{NodeData, NodeId},
-        Error, Mpt,
-    };
-
-    /// [`MptOwned`] is a variant of [`Mpt`] that owns its data. It owns the bump
-    /// arena and has all its data stored in its bump.
-    #[derive(Debug, Clone)]
-    pub(crate) struct MptOwned {
-        inner: Mpt<'static>,
-    }
-
-    impl Default for MptOwned {
-        fn default() -> Self {
-            let bump = Box::leak(Box::new(Bump::new()));
-            Self { inner: Mpt::new(bump) }
-        }
-    }
-
-    impl MptOwned {
-        pub(crate) fn decode_from_proof_rlp(bytes: &mut &[u8]) -> Result<Self, Error> {
-            let bump = Box::leak(Box::new(Bump::new()));
-            let bytes = bump.alloc_slice_copy(bytes);
-            let mut bytes = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(bytes) };
-            let inner = Mpt::decode_from_proof_rlp(bump, &mut bytes)?;
-            Ok(Self { inner })
-        }
-
-        pub(crate) fn from_trie(other: &Mpt<'_>) -> Self {
-            let mut trie = Self::default();
-            for (i, node) in other.nodes.iter().enumerate() {
-                if i < trie.inner.nodes.len() {
-                    trie.set_node(i as NodeId, node);
-                } else {
-                    trie.add_node(node);
-                }
-            }
-            trie.set_root_id(other.root_id);
-            trie
-        }
-
-        pub(crate) fn hash(&self) -> B256 {
-            self.inner.hash()
-        }
-
-        pub(crate) fn root_id(&self) -> NodeId {
-            self.inner.root_id
-        }
-
-        pub(crate) fn get_node(&self, node_id: NodeId) -> Option<&NodeData<'static>> {
-            self.inner.nodes.get(node_id as usize)
-        }
-
-        pub(crate) fn inner(&self) -> &Mpt<'static> {
-            &self.inner
-        }
-
-        pub(crate) fn into_inner(self) -> Mpt<'static> {
-            self.inner
-        }
-
-        pub(crate) fn get(&self, key: &[u8]) -> Result<Option<&'static [u8]>, Error> {
-            self.inner.get(key)
-        }
-
-        fn alloc_in_bump(&self, bytes: &[u8]) -> &'static [u8] {
-            let slice = self.inner.bump.alloc_slice_copy(bytes);
-            // Sound because `slice` lives as long as `self.bump`.
-            unsafe { std::mem::transmute::<&[u8], &'static [u8]>(slice) }
-        }
-
-        pub(crate) fn set_root_id(&mut self, root_id: NodeId) {
-            self.inner.root_id = root_id;
-        }
-
-        /// Sets a node at the specified index, copying any referenced data into the owned bump
-        /// arena.
-        pub(crate) fn set_node(&mut self, node_id: NodeId, data: &NodeData<'_>) {
-            let i = node_id as usize;
-
-            match data {
-                NodeData::Null => {
-                    self.inner.nodes[i] = NodeData::Null;
-                }
-                NodeData::Branch(childs) => {
-                    self.inner.nodes[i] = NodeData::Branch(*childs);
-                }
-                NodeData::Leaf(prefix, value) => {
-                    let prefix = self.alloc_in_bump(prefix);
-                    let value = self.alloc_in_bump(value);
-                    self.inner.nodes[i] = NodeData::Leaf(prefix, value);
-                }
-                NodeData::Extension(prefix, ext_node_id) => {
-                    let prefix = self.alloc_in_bump(prefix);
-                    self.inner.nodes[i] = NodeData::Extension(prefix, *ext_node_id);
-                }
-                NodeData::Digest(digest) => {
-                    let digest = self.alloc_in_bump(digest);
-                    self.inner.nodes[i] = NodeData::Digest(digest);
-                }
-            }
-        }
-
-        /// Adds a new node to the trie, copies the data into its own bump and returns the new
-        /// node's ID.
-        pub(crate) fn add_node(&mut self, data: &NodeData<'_>) -> NodeId {
-            let id = self.inner.add_node(NodeData::Null, None);
-            self.set_node(id, data);
-            id
         }
     }
 }

--- a/crates/stateless-executor/src/io.rs
+++ b/crates/stateless-executor/src/io.rs
@@ -17,9 +17,6 @@ use revm_primitives::{keccak256, map::DefaultHashBuilder, Address, HashMap, B256
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-/// Bump area size in bytes.
-const BUMP_AREA_SIZE: usize = 1000 * 1000;
-
 /// The input for the client to execute a block and fully verify the STF (state transition
 /// function).
 #[serde_as]
@@ -126,17 +123,19 @@ mod tests {
 }
 
 #[derive(Debug, Clone)]
-pub struct StatelessExecutorInputWithState {
-    pub input: &'static StatelessExecutorInput,
-    pub state: EthereumState,
+pub struct StatelessExecutorInputWithState<'a> {
+    pub input: &'a StatelessExecutorInput,
+    pub state: EthereumState<'a>,
 }
 
-impl StatelessExecutorInputWithState {
-    /// Parses `input.parent_state_bytes` into `EthereumState` and verifies state and storage roots.
-    pub fn build(input: StatelessExecutorInput) -> Result<Self, StatelessExecutorError> {
-        let input = Box::leak(Box::new(input));
-        let bump = Box::leak(Box::new(Bump::with_capacity(BUMP_AREA_SIZE)));
-
+impl<'a> StatelessExecutorInputWithState<'a> {
+    /// Parses `input.parent_state_bytes` into `EthereumState` and verifies state and storage
+    /// roots. All trie data is allocated in `bump`; [`BUMP_AREA_SIZE`] is a reasonable initial
+    /// capacity for it.
+    pub fn build(
+        input: &'a StatelessExecutorInput,
+        bump: &'a Bump,
+    ) -> Result<Self, StatelessExecutorError> {
         let state = {
             let (state_num_nodes, state_bytes) = &input.parent_state_bytes.state_trie;
             let state_trie = Mpt::decode_trie(bump, &mut state_bytes.as_ref(), *state_num_nodes)?;
@@ -179,7 +178,7 @@ impl StatelessExecutorInputWithState {
     }
 }
 
-impl StatelessExecutorInputWithState {
+impl<'a> StatelessExecutorInputWithState<'a> {
     /// Gets the immediate parent block's header.
     #[inline(always)]
     pub fn parent_header(&self) -> &Header {
@@ -187,14 +186,14 @@ impl StatelessExecutorInputWithState {
     }
 
     /// Creates a [`WitnessDb`].
-    pub fn witness_db(&self) -> Result<WitnessDb<'_>, StatelessExecutorError> {
+    pub fn witness_db(&self) -> Result<WitnessDb<'a, '_>, StatelessExecutorError> {
         <Self as WitnessInput>::witness_db(self)
     }
 }
 
-impl WitnessInput for StatelessExecutorInputWithState {
+impl<'a> WitnessInput<'a> for StatelessExecutorInputWithState<'a> {
     #[inline(always)]
-    fn state(&self) -> &EthereumState {
+    fn state(&self) -> &EthereumState<'a> {
         &self.state
     }
 
@@ -219,10 +218,11 @@ impl WitnessInput for StatelessExecutorInputWithState {
     }
 }
 
-/// A trait for constructing [`WitnessDb`].
-pub trait WitnessInput {
+/// A trait for constructing [`WitnessDb`]. The lifetime parameter `'a` is the lifetime of the
+/// bump arena backing the state's tries.
+pub trait WitnessInput<'a> {
     /// Gets a reference to the state from which account info and storage slots are loaded.
-    fn state(&self) -> &EthereumState;
+    fn state(&self) -> &EthereumState<'a>;
 
     /// Gets the state trie root hash that the state referenced by
     /// [state()](trait.WitnessInput#tymethod.state) must conform to.
@@ -246,7 +246,7 @@ pub trait WitnessInput {
     /// implementing this trait causes a zkVM run to cost over 5M cycles more. To avoid this, define
     /// a method inside the type that calls this trait method instead.
     #[inline(always)]
-    fn witness_db(&self) -> Result<WitnessDb<'_>, StatelessExecutorError> {
+    fn witness_db(&self) -> Result<WitnessDb<'a, '_>, StatelessExecutorError> {
         let state = self.state();
 
         let bytecode_by_hash =
@@ -278,18 +278,21 @@ pub trait WitnessInput {
     }
 }
 
+/// A database that loads account info and storage slots from a borrowed [`EthereumState`]. The
+/// lifetime parameter `'a` is the lifetime of the bump arena backing the state's tries, and `'b`
+/// is the lifetime of the borrows of the state and bytecodes.
 #[derive(Debug)]
-pub struct WitnessDb<'a> {
-    inner: &'a EthereumState,
+pub struct WitnessDb<'a, 'b> {
+    inner: &'b EthereumState<'a>,
     block_hashes: HashMap<u64, B256>,
-    bytecode_by_hash: HashMap<B256, &'a Bytecode>,
+    bytecode_by_hash: HashMap<B256, &'b Bytecode>,
 }
 
-impl<'a> WitnessDb<'a> {
+impl<'a, 'b> WitnessDb<'a, 'b> {
     pub fn new(
-        inner: &'a EthereumState,
+        inner: &'b EthereumState<'a>,
         block_hashes: HashMap<u64, B256>,
-        bytecode_by_hash: HashMap<B256, &'a Bytecode>,
+        bytecode_by_hash: HashMap<B256, &'b Bytecode>,
     ) -> Self {
         Self { inner, block_hashes, bytecode_by_hash }
     }
@@ -302,7 +305,7 @@ fn trie_error_to_provider_error(trie_error: openvm_mpt::Error) -> ProviderError 
     }
 }
 
-impl DatabaseRef for WitnessDb<'_> {
+impl DatabaseRef for WitnessDb<'_, '_> {
     /// The database error type.
     type Error = ProviderError;
 

--- a/crates/stateless-executor/src/lib.rs
+++ b/crates/stateless-executor/src/lib.rs
@@ -15,6 +15,8 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::block::Block as _;
 use reth_revm::db::CacheDB;
 
+use bumpalo::Bump;
+
 use crate::{
     error::StatelessExecutorError,
     io::{StatelessExecutorInput, StatelessExecutorInputWithState},
@@ -22,6 +24,9 @@ use crate::{
 
 /// Chain ID for Ethereum Mainnet.
 pub const CHAIN_ID_ETH_MAINNET: u64 = 0x1;
+
+/// Initial capacity in bytes for the bump arena backing [`EthereumState`].
+pub const BUMP_AREA_SIZE: usize = 1000 * 1000;
 
 /// An executor that executes a block inside a zkVM.
 #[derive(Debug, Clone, Default)]
@@ -40,7 +45,8 @@ impl StatelessExecutor {
         chain_variant: ChainVariant,
         pre_input: StatelessExecutorInput,
     ) -> Result<Header, StatelessExecutorError> {
-        let mut input = StatelessExecutorInputWithState::build(pre_input)?;
+        let bump = Bump::with_capacity(BUMP_AREA_SIZE);
+        let mut input = StatelessExecutorInputWithState::build(&pre_input, &bump)?;
 
         // Install OpenVM crypto optimizations
         #[cfg(feature = "openvm")]

--- a/crates/stateless-witness/Cargo.toml
+++ b/crates/stateless-witness/Cargo.toml
@@ -31,5 +31,6 @@ itertools.workspace = true
 tracing.workspace = true
 metrics.workspace = true
 thiserror.workspace = true
+bumpalo.workspace = true
 serde.workspace = true
 serde_with.workspace = true

--- a/crates/stateless-witness/src/lib.rs
+++ b/crates/stateless-witness/src/lib.rs
@@ -4,6 +4,7 @@
 use alloy_consensus::{BlockHeader as _, Header};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
+use bumpalo::Bump;
 use itertools::Itertools;
 use openvm_mpt::{resolver::MptResolver, EthereumState};
 use openvm_stateless_executor::io::StatelessExecutorInput;
@@ -70,9 +71,10 @@ pub fn generate_stateless_input_from_witness_and_ancestor_headers(
 ) -> WitnessResult<StatelessExecutorInput> {
     let ExecutionWitness { state: reth_state, codes, keys, headers: _ } = witness.execution_witness;
 
+    let bump = Bump::new();
     let ethereum_state = time!(
         "ethereum_state_resolve",
-        resolve_ethereum_state(witness.parent_state_root, reth_state, keys)
+        resolve_ethereum_state(&bump, witness.parent_state_root, reth_state, keys)
     )?;
 
     let bytecodes = {
@@ -186,12 +188,14 @@ where
     ))
 }
 
-#[instrument(skip(reth_state, keys))]
-pub fn resolve_ethereum_state(
+/// Resolves an [`EthereumState`] from an execution witness. All trie data is allocated in `bump`.
+#[instrument(skip(bump, reth_state, keys))]
+pub fn resolve_ethereum_state<'a>(
+    bump: &'a Bump,
     state_root: B256,
     reth_state: Vec<Bytes>,
     keys: Vec<Bytes>,
-) -> WitnessResult<EthereumState> {
+) -> WitnessResult<EthereumState<'a>> {
     let mut node_store = Vec::with_capacity(reth_state.len());
     let mut has_state_root_node = state_root == EMPTY_ROOT_HASH;
     for node in reth_state {
@@ -207,7 +211,7 @@ pub fn resolve_ethereum_state(
 
     let mpt_resolver = MptResolver::from_iter(node_store);
 
-    let state_trie = mpt_resolver.resolve(&state_root)?;
+    let state_trie = mpt_resolver.resolve(bump, &state_root)?;
     assert_eq!(state_trie.hash(), state_root);
     tracing::debug!(state_root=%state_root, num_nodes=state_trie.num_nodes(), "resolved state trie");
 
@@ -220,7 +224,7 @@ pub fn resolve_ethereum_state(
             .get_rlp::<TrieAccount>(hashed_address.as_slice())?
             .map_or(EMPTY_ROOT_HASH, |a| a.storage_root);
 
-        let storage_trie = mpt_resolver.resolve(&storage_root)?;
+        let storage_trie = mpt_resolver.resolve(bump, &storage_root)?;
         assert_eq!(storage_trie.hash(), storage_root);
         tracing::debug!(
             account=%key,
@@ -231,5 +235,5 @@ pub fn resolve_ethereum_state(
 
         storage_tries.insert(hashed_address, storage_trie);
     }
-    Ok(EthereumState::from_tries(state_trie, storage_tries))
+    Ok(EthereumState::from_tries(state_trie, storage_tries, bump))
 }


### PR DESCRIPTION
Removes `Box::leak` by adding proper lifetimes to `EthereumState`. `Box::leak` causes memory leak when the guest program is run outside of the VM.

Towards INT-8668