### PR TITLE
fix(ci): locate compare-branches metrics json by extension

### DIFF
--- a/.github/workflows/compare-branches.yml
+++ b/.github/workflows/compare-branches.yml
@@ -132,9 +132,11 @@ jobs:
         run: |
           ls
           BASE_NAME=${{ needs.run-base-benchmark.outputs.metric_name }}
-          BASE_JSON=$BASE_NAME/metrics.json
           TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}
-          TARGET_JSON=$TARGET_NAME/metrics.json
+          # The metrics file inside the artifact directory is named <metric_name>.json,
+          # so locate it by extension rather than assuming a fixed metrics.json name.
+          BASE_JSON=$(find $BASE_NAME -name "*.json" | head -1)
+          TARGET_JSON=$(find $TARGET_NAME -name "*.json" | head -1)
 
           openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON
           MD_PATH=${TARGET_JSON%.json}.md


### PR DESCRIPTION
## Problem

The `compare-results` job in `compare-branches.yml` failed even though both benchmark jobs succeeded (e.g. [run 28745680097](https://github.com/axiom-crypto/openvm-eth/actions/runs/28745680097)).

Root cause: benchmark artifacts contain `<metric_name>/<metric_name>.json`, but `compare-branches.yml` hardcoded `<metric_name>/metrics.json`, so `openvm-prof` was pointed at a nonexistent file.

## Fix

Locate the metrics file by extension with `find`, matching the robust pattern already used by the sibling `compare-bench.yml` workflow, rather than assuming a fixed `metrics.json` name.