### PR TITLE
perf: move branch children out of NodeData into the bump arena

### DIFF
--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -2,15 +2,23 @@ use revm_primitives::hex;
 
 pub(crate) type NodeId = u32;
 
-/// Node data for arena-based trie with zero-copy optimization
+/// Index into the owning trie's branch-children arena (`Mpt::branches`).
+pub(crate) type BranchId = u32;
+
+/// Node data for arena-based trie with zero-copy optimization.
+///
+/// Branch children are stored out-of-line in the owning trie's branch arena so this enum stays
+/// small: nodes live in a flat `Vec<NodeData>`, and inlining the 16-child array would make every
+/// node (mostly leaves and digests) pay the branch variant's size when pushed, copied, or moved.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd)]
 pub(crate) enum NodeData<'a> {
     #[default]
     /// Absence of a node. Encoded as empty string in RLP.
     Null,
     /// 16-way branch. Each child is optional; the branch's value slot is unused in our state trie
-    /// and must be empty, enforced during decoding.
-    Branch([Option<NodeId>; 16]),
+    /// and must be empty, enforced during decoding. The id is only meaningful within the owning
+    /// trie.
+    Branch(BranchId),
     /// Leaf node containing a compact hex-prefix path and a value. Both slices borrow from the
     /// input buffer or bump arena. The path encodes the remainder of the key.
     Leaf(&'a [u8], &'a [u8]),

--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -1,24 +1,27 @@
+use std::cell::Cell;
+
 use revm_primitives::hex;
 
 pub(crate) type NodeId = u32;
 
-/// Index into the owning trie's branch-children arena (`Mpt::branches`).
-pub(crate) type BranchId = u32;
+/// Children slots of a branch node, allocated in the trie's bump arena.
+pub(crate) type BranchChildren<'a> = &'a [Cell<Option<NodeId>>; 16];
 
 /// Node data for arena-based trie with zero-copy optimization.
 ///
-/// Branch children are stored out-of-line in the owning trie's branch arena so this enum stays
-/// small: nodes live in a flat `Vec<NodeData>`, and inlining the 16-child array would make every
-/// node (mostly leaves and digests) pay the branch variant's size when pushed, copied, or moved.
+/// Branch children are stored out-of-line in the trie's bump arena so this enum stays small:
+/// nodes live in a flat `Vec<NodeData>`, and inlining the 16-child array would make every node
+/// (mostly leaves and digests) pay the branch variant's size when pushed, copied, or moved. The
+/// slots are `Cell`s so updates can mutate them through the shared reference without re-borrowing
+/// the node list.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd)]
 pub(crate) enum NodeData<'a> {
     #[default]
     /// Absence of a node. Encoded as empty string in RLP.
     Null,
     /// 16-way branch. Each child is optional; the branch's value slot is unused in our state trie
-    /// and must be empty, enforced during decoding. The id is only meaningful within the owning
-    /// trie.
-    Branch(BranchId),
+    /// and must be empty, enforced during decoding.
+    Branch(BranchChildren<'a>),
     /// Leaf node containing a compact hex-prefix path and a value. Both slices borrow from the
     /// input buffer or bump arena. The path encodes the remainder of the key.
     Leaf(&'a [u8], &'a [u8]),

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -82,8 +82,8 @@ impl MptResolver {
                         let child_id = self.resolve_internal(&mut item, mpt)?;
                         childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
                     }
-                    let node_data = NodeData::Branch(childs);
-                    mpt.add_node_copied(&node_data)
+                    let branch_id = mpt.add_branch(childs);
+                    mpt.add_node_copied(&NodeData::Branch(branch_id))
                 }
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -82,8 +82,9 @@ impl MptResolver {
                         let child_id = self.resolve_internal(&mut item, mpt)?;
                         childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
                     }
-                    let branch_id = mpt.add_branch(childs);
-                    mpt.add_node_copied(&NodeData::Branch(branch_id))
+                    // The children array is allocated in `mpt`'s own bump, so no copy is needed.
+                    let children = mpt.alloc_branch(childs);
+                    mpt.add_node(NodeData::Branch(children), None)
                 }
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));

--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -261,8 +261,8 @@ fn test_delete_with_unresolved_sibling_errors() {
     let mut children: [Option<u32>; 16] = Default::default();
     children[0] = Some(leaf_id);
     children[1] = Some(digest_id);
-    let branch_id = trie.add_branch(children);
-    let branch_node_id = trie.add_node(NodeData::Branch(branch_id), None);
+    let branch_children = trie.alloc_branch(children);
+    let branch_node_id = trie.add_node(NodeData::Branch(branch_children), None);
 
     // Set the root to the branch
     trie.set_root_id(branch_node_id);

--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -261,10 +261,11 @@ fn test_delete_with_unresolved_sibling_errors() {
     let mut children: [Option<u32>; 16] = Default::default();
     children[0] = Some(leaf_id);
     children[1] = Some(digest_id);
-    let branch_id = trie.add_node(NodeData::Branch(children), None);
+    let branch_id = trie.add_branch(children);
+    let branch_node_id = trie.add_node(NodeData::Branch(branch_id), None);
 
     // Set the root to the branch
-    trie.set_root_id(branch_id);
+    trie.set_root_id(branch_node_id);
 
     // Now try to delete the key 0x00 (nibbles [0, 0])
     // This should:

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -15,7 +15,7 @@ use crate::{
         encoded_path_eq_nibs, encoded_path_strip_prefix, lcp, prefix_to_nibs,
         to_encoded_path_with_bump, to_nibs,
     },
-    node::{BranchId, NodeData, NodeId, NodeRef},
+    node::{BranchChildren, NodeData, NodeId, NodeRef},
 };
 
 /// OpenVM memory alignment word size.
@@ -57,11 +57,6 @@ pub struct Mpt<'a> {
     /// List of MPT nodes.
     nodes: Vec<NodeData<'a>>,
 
-    /// Children arrays of branch nodes, indexed by [`BranchId`]. Kept out of [`NodeData`] so the
-    /// node list stays compact. Arrays orphaned by structural updates are never reclaimed, just
-    /// like the nodes themselves.
-    branches: Vec<[Option<NodeId>; 16]>,
-
     /// Cache. Hashing/encoding often needs "what would this node look like in its parent"
     cached_references: Vec<Cell<Option<NodeRef<'a>>>>,
 
@@ -90,9 +85,6 @@ impl<'a> Mpt<'a> {
 
         Self {
             nodes,
-            // Branch nodes are a small fraction of witness nodes (each resolved branch child is
-            // its own node, unresolved ones are digest nodes), so 1/8 leaves ample headroom.
-            branches: Vec::with_capacity(capacity / 8),
             rlp_scratch: RefCell::new(Vec::with_capacity(RLP_SCRATCH_INIT_CAPACITY)),
             cached_references,
             bump,
@@ -181,8 +173,8 @@ impl<'a> Mpt<'a> {
         }
 
         match self.nodes[node_id as usize] {
-            NodeData::Branch(branch_id) => {
-                for child_id in self.branches[branch_id as usize].into_iter().flatten() {
+            NodeData::Branch(children) => {
+                for child_id in children.iter().filter_map(Cell::get) {
                     self.encode_trie_internal(child_id, out);
                 }
             }
@@ -390,8 +382,8 @@ impl<'a> Mpt<'a> {
             return Err(Error::ValueInBranch);
         }
 
-        let branch_id = self.add_branch(childs);
-        let node_id = self.add_node(NodeData::Branch(branch_id), Some(node_ref));
+        let children = self.alloc_branch(childs);
+        let node_id = self.add_node(NodeData::Branch(children), Some(node_ref));
         Ok(node_id)
     }
 }
@@ -444,11 +436,11 @@ impl<'a> Mpt<'a> {
             NodeData::Null => {
                 out.put_u8(alloy_rlp::EMPTY_STRING_CODE);
             }
-            NodeData::Branch(branch_id) => {
+            NodeData::Branch(children) => {
                 encode_header(alloy_rlp::EMPTY_LIST_CODE, payload_length, out);
-                for child_id in self.branches[*branch_id as usize].iter() {
-                    match child_id {
-                        Some(id) => self.reference_encode(*id, out),
+                for child_id in children.iter() {
+                    match child_id.get() {
+                        Some(id) => self.reference_encode(id, out),
                         None => out.put_u8(alloy_rlp::EMPTY_STRING_CODE),
                     }
                 }
@@ -498,10 +490,10 @@ impl<'a> Mpt<'a> {
     fn payload_length(&self, node_id: NodeId) -> usize {
         match &self.nodes[node_id as usize] {
             NodeData::Null => 0,
-            NodeData::Branch(branch_id) => {
-                1 + self.branches[*branch_id as usize]
+            NodeData::Branch(children) => {
+                1 + children
                     .iter()
-                    .map(|child| child.map_or(1, |id| self.reference_length(id)))
+                    .map(|child| child.get().map_or(1, |id| self.reference_length(id)))
                     .sum::<usize>()
             }
             NodeData::Leaf(encoded_path, value) => encoded_path.length() + value.length(),
@@ -613,7 +605,6 @@ impl<'a> Mpt<'a> {
     pub fn reserve(&mut self, additional: usize) {
         self.nodes.reserve(additional);
         self.cached_references.reserve(additional);
-        self.branches.reserve(additional / 8);
     }
 }
 
@@ -627,13 +618,11 @@ impl<'a> Mpt<'a> {
         id
     }
 
-    /// Adds a branch children array to the arena and returns its id, to be stored in a
-    /// [`NodeData::Branch`] of this trie.
+    /// Allocates a branch children array in the bump arena, to be stored in a
+    /// [`NodeData::Branch`].
     #[inline]
-    pub(crate) fn add_branch(&mut self, children: [Option<NodeId>; 16]) -> BranchId {
-        let id = self.branches.len() as BranchId;
-        self.branches.push(children);
-        id
+    pub(crate) fn alloc_branch(&self, children: [Option<NodeId>; 16]) -> BranchChildren<'a> {
+        self.bump.alloc(children.map(Cell::new))
     }
 
     /// Sets the root node ID. Used by the resolver and by tests to construct tries with specific
@@ -644,13 +633,15 @@ impl<'a> Mpt<'a> {
         self.root_id = root_id;
     }
 
-    /// Adds a new node to the trie, copying any borrowed slices into the trie's bump arena, and
-    /// returns the new node's ID. A `Branch`'s id must already refer to this trie's branch arena.
+    /// Adds a new node to the trie, copying any borrowed slices (and branch children) into the
+    /// trie's bump arena, and returns the new node's ID.
     #[cfg(feature = "host")]
     pub(crate) fn add_node_copied(&mut self, data: &NodeData<'_>) -> NodeId {
         let data = match data {
             NodeData::Null => NodeData::Null,
-            NodeData::Branch(branch_id) => NodeData::Branch(*branch_id),
+            NodeData::Branch(children) => {
+                NodeData::Branch(self.alloc_branch(children.each_ref().map(Cell::get)))
+            }
             NodeData::Leaf(prefix, value) => NodeData::Leaf(
                 self.bump.alloc_slice_copy(prefix),
                 self.bump.alloc_slice_copy(value),
@@ -672,9 +663,9 @@ impl<'a> Mpt<'a> {
     fn get_internal(&self, node_id: NodeId, key_nibs: &[u8]) -> Result<Option<&'a [u8]>, Error> {
         match &self.nodes[node_id as usize] {
             NodeData::Null => Ok(None),
-            NodeData::Branch(branch_id) => {
+            NodeData::Branch(children) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    match self.branches[*branch_id as usize][*i as usize] {
+                    match children[*i as usize].get() {
                         Some(id) => self.get_internal(id, tail),
                         None => Ok(None),
                     }
@@ -715,14 +706,14 @@ impl<'a> Mpt<'a> {
                 self.nodes[node_id as usize] = NodeData::Leaf(path, value);
                 true
             }
-            NodeData::Branch(branch_id) => {
+            NodeData::Branch(children) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    match self.branches[branch_id as usize][*i as usize] {
+                    match children[*i as usize].get() {
                         Some(id) => self.insert_internal(id, tail, value)?,
                         None => {
                             let path = to_encoded_path_with_bump(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            self.branches[branch_id as usize][*i as usize] = Some(new_leaf_id);
+                            children[*i as usize].set(Some(new_leaf_id));
                             true
                         }
                     }
@@ -760,9 +751,10 @@ impl<'a> Mpt<'a> {
                         children[self_nibs[common_len] as usize] = Some(leaf1_id);
                         children[key_nibs[common_len] as usize] = Some(leaf2_id);
 
-                        let branch_id = self.add_branch(children);
+                        let branch_children = self.alloc_branch(children);
                         let new_node_data = if common_len > 0 {
-                            let branch_node_id = self.add_node(NodeData::Branch(branch_id), None);
+                            let branch_node_id =
+                                self.add_node(NodeData::Branch(branch_children), None);
                             let ext_path_slice = to_encoded_path_with_bump(
                                 self.bump,
                                 &self_nibs[..common_len],
@@ -770,7 +762,7 @@ impl<'a> Mpt<'a> {
                             );
                             NodeData::Extension(ext_path_slice, branch_node_id)
                         } else {
-                            NodeData::Branch(branch_id)
+                            NodeData::Branch(branch_children)
                         };
                         self.nodes[node_id as usize] = new_node_data;
                         true
@@ -804,14 +796,14 @@ impl<'a> Mpt<'a> {
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
                     children[key_nibs[common_len] as usize] = Some(leaf_id);
 
-                    let branch_id = self.add_branch(children);
+                    let branch_children = self.alloc_branch(children);
                     let new_node_data = if common_len > 0 {
-                        let branch_node_id = self.add_node(NodeData::Branch(branch_id), None);
+                        let branch_node_id = self.add_node(NodeData::Branch(branch_children), None);
                         let parent_ext_path_slice =
                             to_encoded_path_with_bump(self.bump, &self_nibs[..common_len], false);
                         NodeData::Extension(parent_ext_path_slice, branch_node_id)
                     } else {
-                        NodeData::Branch(branch_id)
+                        NodeData::Branch(branch_children)
                     };
                     self.nodes[node_id as usize] = new_node_data;
                     true
@@ -833,10 +825,9 @@ impl<'a> Mpt<'a> {
     fn delete_internal(&mut self, node_id: NodeId, key_nibs: &[u8]) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => false,
-            NodeData::Branch(branch_id) => {
+            NodeData::Branch(children) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    let child_id = self.branches[branch_id as usize][*i as usize];
-                    match child_id {
+                    match children[*i as usize].get() {
                         Some(id) => {
                             if !self.delete_internal(id, tail)? {
                                 return Ok(false);
@@ -844,7 +835,7 @@ impl<'a> Mpt<'a> {
 
                             // if the node is now empty, remove it
                             if matches!(self.nodes[id as usize], NodeData::Null) {
-                                self.branches[branch_id as usize][*i as usize] = None;
+                                children[*i as usize].set(None);
                             }
                         }
                         None => return Ok(false),
@@ -853,14 +844,13 @@ impl<'a> Mpt<'a> {
                     return Err(Error::ValueInBranch);
                 }
 
-                let mut remaining_iter = self.branches[branch_id as usize]
+                let mut remaining_iter = children
                     .iter()
                     .enumerate()
-                    .filter(|(_, n)| n.is_some());
+                    .filter_map(|(index, n)| n.get().map(|id| (index, id)));
 
                 // there will always be at least one remaining node
                 let (index, child_id) = remaining_iter.next().unwrap();
-                let child_id = child_id.unwrap();
 
                 // if there is only exactly one node left, we need to convert the branch
                 if remaining_iter.next().is_none() {
@@ -897,7 +887,7 @@ impl<'a> Mpt<'a> {
                     };
                     self.nodes[node_id as usize] = new_node_data;
                 }
-                // otherwise the children were already updated in place in the branch arena
+                // otherwise the children were already updated in place through their cells
 
                 true
             }
@@ -1010,8 +1000,8 @@ impl<'a> Mpt<'a> {
                         let child_id = self.decode_from_proof_rlp_internal(&mut item)?;
                         childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
                     }
-                    let branch_id = self.add_branch(childs);
-                    self.add_node(NodeData::Branch(branch_id), None)
+                    let children = self.alloc_branch(childs);
+                    self.add_node(NodeData::Branch(children), None)
                 }
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));
@@ -1039,8 +1029,8 @@ impl<'a> Mpt<'a> {
         payloads.push(buffer_bytes);
 
         match &self.nodes[node_id as usize] {
-            NodeData::Branch(branch_id) => {
-                for child_id in self.branches[*branch_id as usize].into_iter().flatten() {
+            NodeData::Branch(children) => {
+                for child_id in children.iter().filter_map(Cell::get) {
                     self.payloads_internal(child_id, payloads);
                 }
             }
@@ -1063,12 +1053,12 @@ impl Mpt<'_> {
             NodeData::Null => {
                 println!("{}Null", indent);
             }
-            NodeData::Branch(branch_id) => {
+            NodeData::Branch(children) => {
                 println!("{}Branch", indent);
-                for (i, child) in self.branches[*branch_id as usize].iter().enumerate() {
-                    if let Some(child_id) = child {
+                for (i, child) in children.iter().enumerate() {
+                    if let Some(child_id) = child.get() {
                         println!("{}  [{}]:", indent, hex::encode([i as u8]));
-                        self.print_trie_internal(*child_id, depth + 2);
+                        self.print_trie_internal(child_id, depth + 2);
                     }
                 }
             }

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -15,7 +15,7 @@ use crate::{
         encoded_path_eq_nibs, encoded_path_strip_prefix, lcp, prefix_to_nibs,
         to_encoded_path_with_bump, to_nibs,
     },
-    node::{NodeData, NodeId, NodeRef},
+    node::{BranchId, NodeData, NodeId, NodeRef},
 };
 
 /// OpenVM memory alignment word size.
@@ -57,6 +57,11 @@ pub struct Mpt<'a> {
     /// List of MPT nodes.
     nodes: Vec<NodeData<'a>>,
 
+    /// Children arrays of branch nodes, indexed by [`BranchId`]. Kept out of [`NodeData`] so the
+    /// node list stays compact. Arrays orphaned by structural updates are never reclaimed, just
+    /// like the nodes themselves.
+    branches: Vec<[Option<NodeId>; 16]>,
+
     /// Cache. Hashing/encoding often needs "what would this node look like in its parent"
     cached_references: Vec<Cell<Option<NodeRef<'a>>>>,
 
@@ -85,6 +90,9 @@ impl<'a> Mpt<'a> {
 
         Self {
             nodes,
+            // Branch nodes are a small fraction of witness nodes (each resolved branch child is
+            // its own node, unresolved ones are digest nodes), so 1/8 leaves ample headroom.
+            branches: Vec::with_capacity(capacity / 8),
             rlp_scratch: RefCell::new(Vec::with_capacity(RLP_SCRATCH_INIT_CAPACITY)),
             cached_references,
             bump,
@@ -173,12 +181,10 @@ impl<'a> Mpt<'a> {
         }
 
         match self.nodes[node_id as usize] {
-            NodeData::Branch(childs) => {
-                childs.iter().for_each(|c| {
-                    if let Some(child_id) = c {
-                        self.encode_trie_internal(*child_id, out)
-                    }
-                });
+            NodeData::Branch(branch_id) => {
+                for child_id in self.branches[branch_id as usize].into_iter().flatten() {
+                    self.encode_trie_internal(child_id, out);
+                }
             }
             NodeData::Extension(_, ext_id) => {
                 self.encode_trie_internal(ext_id, out);
@@ -384,8 +390,8 @@ impl<'a> Mpt<'a> {
             return Err(Error::ValueInBranch);
         }
 
-        let node_data = NodeData::Branch(childs);
-        let node_id = self.add_node(node_data, Some(node_ref));
+        let branch_id = self.add_branch(childs);
+        let node_id = self.add_node(NodeData::Branch(branch_id), Some(node_ref));
         Ok(node_id)
     }
 }
@@ -438,9 +444,9 @@ impl<'a> Mpt<'a> {
             NodeData::Null => {
                 out.put_u8(alloy_rlp::EMPTY_STRING_CODE);
             }
-            NodeData::Branch(nodes) => {
+            NodeData::Branch(branch_id) => {
                 encode_header(alloy_rlp::EMPTY_LIST_CODE, payload_length, out);
-                for child_id in nodes.iter() {
+                for child_id in self.branches[*branch_id as usize].iter() {
                     match child_id {
                         Some(id) => self.reference_encode(*id, out),
                         None => out.put_u8(alloy_rlp::EMPTY_STRING_CODE),
@@ -492,8 +498,8 @@ impl<'a> Mpt<'a> {
     fn payload_length(&self, node_id: NodeId) -> usize {
         match &self.nodes[node_id as usize] {
             NodeData::Null => 0,
-            NodeData::Branch(nodes) => {
-                1 + nodes
+            NodeData::Branch(branch_id) => {
+                1 + self.branches[*branch_id as usize]
                     .iter()
                     .map(|child| child.map_or(1, |id| self.reference_length(id)))
                     .sum::<usize>()
@@ -607,6 +613,7 @@ impl<'a> Mpt<'a> {
     pub fn reserve(&mut self, additional: usize) {
         self.nodes.reserve(additional);
         self.cached_references.reserve(additional);
+        self.branches.reserve(additional / 8);
     }
 }
 
@@ -620,6 +627,15 @@ impl<'a> Mpt<'a> {
         id
     }
 
+    /// Adds a branch children array to the arena and returns its id, to be stored in a
+    /// [`NodeData::Branch`] of this trie.
+    #[inline]
+    pub(crate) fn add_branch(&mut self, children: [Option<NodeId>; 16]) -> BranchId {
+        let id = self.branches.len() as BranchId;
+        self.branches.push(children);
+        id
+    }
+
     /// Sets the root node ID. Used by the resolver and by tests to construct tries with specific
     /// structure.
     #[cfg(any(test, feature = "host"))]
@@ -629,12 +645,12 @@ impl<'a> Mpt<'a> {
     }
 
     /// Adds a new node to the trie, copying any borrowed slices into the trie's bump arena, and
-    /// returns the new node's ID.
+    /// returns the new node's ID. A `Branch`'s id must already refer to this trie's branch arena.
     #[cfg(feature = "host")]
     pub(crate) fn add_node_copied(&mut self, data: &NodeData<'_>) -> NodeId {
         let data = match data {
             NodeData::Null => NodeData::Null,
-            NodeData::Branch(childs) => NodeData::Branch(*childs),
+            NodeData::Branch(branch_id) => NodeData::Branch(*branch_id),
             NodeData::Leaf(prefix, value) => NodeData::Leaf(
                 self.bump.alloc_slice_copy(prefix),
                 self.bump.alloc_slice_copy(value),
@@ -656,9 +672,9 @@ impl<'a> Mpt<'a> {
     fn get_internal(&self, node_id: NodeId, key_nibs: &[u8]) -> Result<Option<&'a [u8]>, Error> {
         match &self.nodes[node_id as usize] {
             NodeData::Null => Ok(None),
-            NodeData::Branch(nodes) => {
+            NodeData::Branch(branch_id) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    match nodes[*i as usize] {
+                    match self.branches[*branch_id as usize][*i as usize] {
                         Some(id) => self.get_internal(id, tail),
                         None => Ok(None),
                     }
@@ -699,15 +715,14 @@ impl<'a> Mpt<'a> {
                 self.nodes[node_id as usize] = NodeData::Leaf(path, value);
                 true
             }
-            NodeData::Branch(mut children) => {
+            NodeData::Branch(branch_id) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize] {
+                    match self.branches[branch_id as usize][*i as usize] {
                         Some(id) => self.insert_internal(id, tail, value)?,
                         None => {
                             let path = to_encoded_path_with_bump(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            children[*i as usize] = Some(new_leaf_id);
-                            self.nodes[node_id as usize] = NodeData::Branch(children);
+                            self.branches[branch_id as usize][*i as usize] = Some(new_leaf_id);
                             true
                         }
                     }
@@ -745,16 +760,17 @@ impl<'a> Mpt<'a> {
                         children[self_nibs[common_len] as usize] = Some(leaf1_id);
                         children[key_nibs[common_len] as usize] = Some(leaf2_id);
 
+                        let branch_id = self.add_branch(children);
                         let new_node_data = if common_len > 0 {
-                            let branch_id = self.add_node(NodeData::Branch(children), None);
+                            let branch_node_id = self.add_node(NodeData::Branch(branch_id), None);
                             let ext_path_slice = to_encoded_path_with_bump(
                                 self.bump,
                                 &self_nibs[..common_len],
                                 false,
                             );
-                            NodeData::Extension(ext_path_slice, branch_id)
+                            NodeData::Extension(ext_path_slice, branch_node_id)
                         } else {
-                            NodeData::Branch(children)
+                            NodeData::Branch(branch_id)
                         };
                         self.nodes[node_id as usize] = new_node_data;
                         true
@@ -788,13 +804,14 @@ impl<'a> Mpt<'a> {
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
                     children[key_nibs[common_len] as usize] = Some(leaf_id);
 
+                    let branch_id = self.add_branch(children);
                     let new_node_data = if common_len > 0 {
-                        let branch_id = self.add_node(NodeData::Branch(children), None);
+                        let branch_node_id = self.add_node(NodeData::Branch(branch_id), None);
                         let parent_ext_path_slice =
                             to_encoded_path_with_bump(self.bump, &self_nibs[..common_len], false);
-                        NodeData::Extension(parent_ext_path_slice, branch_id)
+                        NodeData::Extension(parent_ext_path_slice, branch_node_id)
                     } else {
-                        NodeData::Branch(children)
+                        NodeData::Branch(branch_id)
                     };
                     self.nodes[node_id as usize] = new_node_data;
                     true
@@ -816,9 +833,9 @@ impl<'a> Mpt<'a> {
     fn delete_internal(&mut self, node_id: NodeId, key_nibs: &[u8]) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => false,
-            NodeData::Branch(mut children) => {
+            NodeData::Branch(branch_id) => {
                 if let Some((i, tail)) = key_nibs.split_first() {
-                    let child_id = children[*i as usize];
+                    let child_id = self.branches[branch_id as usize][*i as usize];
                     match child_id {
                         Some(id) => {
                             if !self.delete_internal(id, tail)? {
@@ -827,7 +844,7 @@ impl<'a> Mpt<'a> {
 
                             // if the node is now empty, remove it
                             if matches!(self.nodes[id as usize], NodeData::Null) {
-                                children[*i as usize] = None;
+                                self.branches[branch_id as usize][*i as usize] = None;
                             }
                         }
                         None => return Ok(false),
@@ -836,7 +853,10 @@ impl<'a> Mpt<'a> {
                     return Err(Error::ValueInBranch);
                 }
 
-                let mut remaining_iter = children.iter().enumerate().filter(|(_, n)| n.is_some());
+                let mut remaining_iter = self.branches[branch_id as usize]
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, n)| n.is_some());
 
                 // there will always be at least one remaining node
                 let (index, child_id) = remaining_iter.next().unwrap();
@@ -876,9 +896,8 @@ impl<'a> Mpt<'a> {
                         NodeData::Null => unreachable!(),
                     };
                     self.nodes[node_id as usize] = new_node_data;
-                } else {
-                    self.nodes[node_id as usize] = NodeData::Branch(children);
                 }
+                // otherwise the children were already updated in place in the branch arena
 
                 true
             }
@@ -991,8 +1010,8 @@ impl<'a> Mpt<'a> {
                         let child_id = self.decode_from_proof_rlp_internal(&mut item)?;
                         childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
                     }
-                    let node_data = NodeData::Branch(childs);
-                    self.add_node(node_data, None)
+                    let branch_id = self.add_branch(childs);
+                    self.add_node(NodeData::Branch(branch_id), None)
                 }
                 _ => {
                     return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));
@@ -1020,9 +1039,8 @@ impl<'a> Mpt<'a> {
         payloads.push(buffer_bytes);
 
         match &self.nodes[node_id as usize] {
-            NodeData::Branch(nodes) => {
-                for child_id in nodes.iter().filter(|c| c.is_some()) {
-                    let child_id = child_id.unwrap();
+            NodeData::Branch(branch_id) => {
+                for child_id in self.branches[*branch_id as usize].into_iter().flatten() {
                     self.payloads_internal(child_id, payloads);
                 }
             }
@@ -1045,9 +1063,9 @@ impl Mpt<'_> {
             NodeData::Null => {
                 println!("{}Null", indent);
             }
-            NodeData::Branch(children) => {
+            NodeData::Branch(branch_id) => {
                 println!("{}Branch", indent);
-                for (i, child) in children.iter().enumerate() {
+                for (i, child) in self.branches[*branch_id as usize].iter().enumerate() {
                     if let Some(child_id) = child {
                         println!("{}  [{}]:", indent, hex::encode([i as u8]));
                         self.print_trie_internal(*child_id, depth + 2);

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -342,10 +342,18 @@ impl<'a> Mpt<'a> {
             }
         };
 
-        // Create an uninitialized array to avoid wasteful default initialization
-        // SAFETY: below we assign to each element of the array.
-        let mut childs: [MaybeUninit<Option<NodeId>>; 16] =
-            unsafe { MaybeUninit::uninit().assume_init() };
+        // Allocate the children slots directly in the bump arena and fill them as they are
+        // decoded, avoiding a stack staging array that would then be copied into the arena.
+        // SAFETY: the allocation matches the layout of the target array type, and every element
+        // is written exactly once below before the array is cast to its initialized type. On an
+        // early error return the partially initialized allocation is abandoned, never read.
+        let childs = unsafe {
+            &mut *self
+                .bump
+                .alloc_layout(std::alloc::Layout::new::<[Cell<Option<NodeId>>; 16]>())
+                .cast::<[MaybeUninit<Option<NodeId>>; 16]>()
+                .as_ptr()
+        };
 
         // Initialize first two elements
         childs[0] = MaybeUninit::new(child0);
@@ -372,17 +380,17 @@ impl<'a> Mpt<'a> {
             });
         }
 
-        // Transmute the fully initialized array to the final type
-        // SAFETY: we already initialized all elements of the array.
-        let childs: [Option<NodeId>; 16] = unsafe {
-            std::mem::transmute::<[MaybeUninit<Option<NodeId>>; 16], [Option<NodeId>; 16]>(childs)
-        };
-
         if !is_null_ref(payload) {
             return Err(Error::ValueInBranch);
         }
 
-        let children = self.alloc_branch(childs);
+        // Cast the fully initialized array to the final type.
+        // SAFETY: all elements of the array were initialized above, and `Cell<T>` is
+        // `repr(transparent)` over `T`.
+        let children: BranchChildren<'a> = unsafe {
+            &*(childs as *const [MaybeUninit<Option<NodeId>>; 16]
+                as *const [Cell<Option<NodeId>>; 16])
+        };
         let node_id = self.add_node(NodeData::Branch(children), Some(node_ref));
         Ok(node_id)
     }


### PR DESCRIPTION
`NodeData` inlined the 16-child branch array (`[Option<NodeId>; 16]`), making the enum ~130 bytes on rv32 even though most witness nodes are digests and leaves that need ~20. Every node push during trie decoding copied the full enum size, and `insert`/`delete` copied the whole children array out of and back into the node vector at every branch level of every update path.

Branch children now live out-of-line in the trie's existing bump arena, referenced directly from the node: `NodeData::Branch(&'a [Cell<Option<NodeId>>; 16])`.

- `NodeData` shrinks ~130 → ~20 bytes, so decode pushes copy ~6× less and the node vector's footprint (with its growth headroom) shrinks accordingly, cutting touched-memory costs on the proving side.
- The `Cell` slots let updates mutate children in place through the shared reference — no copy-out/copy-in per branch level, and no re-borrow of the node list.
- During decode, the children array is allocated in the bump arena up front and each slot is written exactly once as it is parsed — no stack staging array, and the previous `MaybeUninit`-array-then-`transmute` dance is replaced by an equivalent in-arena one.
- Children arrays orphaned by structural updates (branch collapse, leaf/extension splits) are never reclaimed, matching the existing semantics of the node vector itself.

Per review, this replaces the first revision's side `Vec<[Option<NodeId>; 16]>` + `u32` id: the pointer goes straight into the enum, dropping one indirection level (and its bounds check) from every branch-child access, plus the separate arena and its capacity sizing.

## Benchmark results

Block 23992138, prove-stark, g7e.2xlarge. Base `main` at #649 (includes the #649/#650 memcmp optimizations); instruction/row/cell counts are deterministic. Runs: [main vs PR-rev2](https://github.com/axiom-crypto/openvm-eth/actions/runs/29031411888), [rev1 vs rev2](https://github.com/axiom-crypto/openvm-eth/actions/runs/29082266216), [rev1 vs final](https://github.com/axiom-crypto/openvm-eth/actions/runs/29083809658).

| metric | main | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 711,802,894 | 708,067,128 | **−3,735,766 (−0.53%)** |
| `total_cells` | 64,805,150,399 | 64,178,350,072 | **−626,800,327 (−0.97%)** |
| `rows` | 1,322,750,225 | 1,319,323,277 | −3,426,948 (−0.26%) |
| app segments | 78 | 77 | −1 |
| `total_proof_time_ms` (same-run, vs rev1) | 79,806 | 79,182 | −0.78% |

Revision breakdown (same base): the direct-pointer design cut traversal cost (branch/compare AIR rows down ~1%) but its first cut staged children on the stack and copied them into the arena, costing +0.47% cells over the side-vec revision; filling the arena in place during decode removed the staging entirely and nets −0.78% cells vs the side-vec revision.

The `compare-results` job failed only on the known artifact-path issue (#632); numbers were aggregated from the run artifacts directly.
