### PR TITLE
feat(mpt): reusable feature-gated witness module (WitnessDb/WitnessInput)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7482,11 +7482,14 @@ dependencies = [
 name = "openvm-mpt"
 version = "0.4.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-rlp",
  "alloy-trie 0.9.4",
  "bumpalo",
  "bytes",
  "hex-literal",
+ "itertools 0.14.0",
+ "reth-evm",
  "revm 40.0.3",
  "revm-primitives 24.0.1",
  "serde",
@@ -8083,7 +8086,6 @@ dependencies = [
  "alloy-trie 0.9.4",
  "bincode 2.0.1",
  "bumpalo",
- "itertools 0.14.0",
  "openvm-chainspec",
  "openvm-mpt",
  "openvm-revm-crypto",

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2505,10 +2505,13 @@ dependencies = [
 name = "openvm-mpt"
 version = "0.4.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-rlp",
  "alloy-trie",
  "bumpalo",
  "bytes",
+ "itertools 0.14.0",
+ "reth-evm",
  "revm",
  "revm-primitives",
  "serde",
@@ -2624,7 +2627,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "bumpalo",
- "itertools 0.14.0",
  "openvm-chainspec",
  "openvm-mpt",
  "openvm-revm-crypto",

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -21,6 +21,11 @@ revm-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
 
+# `witness` feature only
+alloy-consensus = { workspace = true, optional = true }
+reth-evm = { workspace = true, optional = true }
+itertools = { workspace = true, optional = true }
+
 [dev-dependencies]
 hex-literal.workspace = true
 
@@ -30,3 +35,6 @@ workspace = true
 [features]
 default = []
 host = []
+# Enables the `witness` module (`WitnessDb` / `WitnessInput`), which pulls in `reth-evm` and
+# `alloy-consensus`. Kept out of the default build so lean MPT consumers don't take those deps.
+witness = ["dep:alloy-consensus", "dep:reth-evm", "dep:itertools"]

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -11,5 +11,8 @@ mod node;
 #[cfg(feature = "host")]
 pub mod resolver;
 
+#[cfg(feature = "witness")]
+pub mod witness;
+
 #[cfg(test)]
 mod tests;

--- a/crates/mpt/src/witness.rs
+++ b/crates/mpt/src/witness.rs
@@ -1,0 +1,181 @@
+//! Reusable witness database backed by a borrowed [`EthereumState`].
+//!
+//! [`WitnessDb`] implements [`revm::DatabaseRef`] by reading accounts, storage slots and
+//! bytecodes directly out of the state's tries, and [`WitnessInput`] verifies the ancestor
+//! header chain and assembles a [`WitnessDb`] from any input that can expose the required
+//! pieces. Both are generic over the concrete input type so downstreams (the OpenVM stateless
+//! executor, and third-party executors with their own input encodings) can reuse them instead
+//! of maintaining a copy.
+//!
+//! This module is gated behind the `witness` cargo feature because it pulls in `reth-evm`
+//! (for [`ProviderError`]) and `alloy-consensus` (for [`Header`]).
+
+use alloy_consensus::Header;
+use alloy_trie::TrieAccount;
+use itertools::Itertools;
+use reth_evm::execute::ProviderError;
+use revm::{
+    state::{AccountInfo, Bytecode},
+    DatabaseRef,
+};
+use revm_primitives::{keccak256, map::DefaultHashBuilder, Address, HashMap, B256, U256};
+
+use crate::{Error, EthereumState};
+
+/// Errors raised while verifying the ancestor header chain during [`WitnessDb`] construction.
+#[derive(thiserror::Error, Debug)]
+pub enum WitnessError {
+    #[error(
+        "non-consecutive block headers: parent block number {parent_block_number}, child block number {child_block_number}"
+    )]
+    NonConsecutiveBlockHeaders { parent_block_number: u64, child_block_number: u64 },
+
+    #[error(
+        "parent block hash mismatch at block number {parent_block_number}: expected {expected}, got {actual}"
+    )]
+    ParentBlockHashMismatch { parent_block_number: u64, expected: B256, actual: B256 },
+}
+
+/// A trait for constructing [`WitnessDb`]. The lifetime parameter `'a` is the lifetime of the
+/// bump arena backing the state's tries.
+pub trait WitnessInput<'a> {
+    /// Gets a reference to the state from which account info and storage slots are loaded.
+    fn state(&self) -> &EthereumState<'a>;
+
+    /// Gets the state trie root hash that the state referenced by
+    /// [state()](trait.WitnessInput#tymethod.state) must conform to.
+    fn state_anchor(&self) -> B256;
+
+    /// Gets an iterator over account bytecodes.
+    fn bytecodes(&self) -> impl Iterator<Item = &Bytecode>;
+
+    /// Gets an iterator over references to a consecutive, reverse-chronological block headers
+    /// starting from the current block header.
+    fn headers(&self) -> impl Iterator<Item = &Header>;
+
+    /// Gets the number of headers.
+    fn headers_len(&self) -> usize;
+
+    /// Creates a [`WitnessDb`] from a [`WitnessInput`] implementation. To do so, it verifies the
+    /// state root, ancestor headers and account bytecodes, and constructs the account and
+    /// storage values by reading against state tries.
+    ///
+    /// NOTE: For some unknown reasons, calling this trait method directly from outside of the type
+    /// implementing this trait causes a zkVM run to cost over 5M cycles more. To avoid this, define
+    /// a method inside the type that calls this trait method instead.
+    #[inline(always)]
+    fn witness_db(&self) -> Result<WitnessDb<'a, '_>, WitnessError> {
+        let state = self.state();
+
+        let bytecode_by_hash =
+            self.bytecodes().map(|code| (code.hash_slow(), code)).collect::<HashMap<_, _>>();
+
+        // Verify and build block hashes
+        let mut block_hashes: HashMap<u64, B256, _> =
+            HashMap::with_capacity_and_hasher(self.headers_len(), DefaultHashBuilder::default());
+        for (child_header, parent_header) in self.headers().tuple_windows() {
+            if parent_header.number != child_header.number - 1 {
+                return Err(WitnessError::NonConsecutiveBlockHeaders {
+                    parent_block_number: parent_header.number,
+                    child_block_number: child_header.number,
+                });
+            }
+
+            if parent_header.hash_slow() != child_header.parent_hash {
+                return Err(WitnessError::ParentBlockHashMismatch {
+                    parent_block_number: parent_header.number,
+                    expected: parent_header.hash_slow(),
+                    actual: child_header.parent_hash,
+                });
+            }
+
+            block_hashes.insert(parent_header.number, child_header.parent_hash);
+        }
+
+        Ok(WitnessDb { inner: state, block_hashes, bytecode_by_hash })
+    }
+}
+
+/// A database that loads account info and storage slots from a borrowed [`EthereumState`]. The
+/// lifetime parameter `'a` is the lifetime of the bump arena backing the state's tries, and `'b`
+/// is the lifetime of the borrows of the state and bytecodes.
+#[derive(Debug)]
+pub struct WitnessDb<'a, 'b> {
+    inner: &'b EthereumState<'a>,
+    block_hashes: HashMap<u64, B256>,
+    bytecode_by_hash: HashMap<B256, &'b Bytecode>,
+}
+
+impl<'a, 'b> WitnessDb<'a, 'b> {
+    pub fn new(
+        inner: &'b EthereumState<'a>,
+        block_hashes: HashMap<u64, B256>,
+        bytecode_by_hash: HashMap<B256, &'b Bytecode>,
+    ) -> Self {
+        Self { inner, block_hashes, bytecode_by_hash }
+    }
+}
+
+fn trie_error_to_provider_error(trie_error: Error) -> ProviderError {
+    match trie_error {
+        Error::RlpError(error) => ProviderError::Rlp(error),
+        _ => ProviderError::TrieWitnessError(trie_error.to_string()),
+    }
+}
+
+impl DatabaseRef for WitnessDb<'_, '_> {
+    /// The database error type.
+    type Error = ProviderError;
+
+    /// Get basic account information.
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let hashed_address = keccak256(address);
+
+        let account_in_trie = self
+            .inner
+            .state_trie
+            .get_rlp::<TrieAccount>(hashed_address.as_slice())
+            .map_err(trie_error_to_provider_error)?;
+
+        let account = account_in_trie.map(|account_in_trie| AccountInfo {
+            balance: account_in_trie.balance,
+            nonce: account_in_trie.nonce,
+            code_hash: account_in_trie.code_hash,
+            code: None,
+            account_id: None,
+        });
+
+        Ok(account)
+    }
+
+    /// Get account code by its hash.
+    fn code_by_hash_ref(&self, hash: B256) -> Result<Bytecode, Self::Error> {
+        // Cloning here is fine as `Bytes` is cheap to clone.
+        self.bytecode_by_hash.get(&hash).map(|code| (*code).clone()).ok_or_else(|| {
+            ProviderError::TrieWitnessError(format!("bytecode for {hash} not found"))
+        })
+    }
+
+    /// Get storage value of address at index.
+    ///
+    /// Returns `U256::ZERO` if the slot is not found in the trie.
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let hashed_address = keccak256(address);
+
+        let storage_trie = self.inner.storage_tries.get(&hashed_address).ok_or_else(|| {
+            ProviderError::TrieWitnessError(format!("storage trie for {address} not found"))
+        })?;
+
+        let hashed_slot = keccak256(index.to_be_bytes::<32>());
+        let storage_value = storage_trie
+            .get_rlp::<U256>(hashed_slot.as_slice())
+            .map_err(trie_error_to_provider_error)?
+            .unwrap_or_default();
+        Ok(storage_value)
+    }
+
+    /// Get block hash by block number.
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.block_hashes.get(&number).copied().ok_or(ProviderError::StateForNumberNotFound(number))
+    }
+}

--- a/crates/stateless-executor/Cargo.toml
+++ b/crates/stateless-executor/Cargo.toml
@@ -14,11 +14,10 @@ thiserror.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 bumpalo.workspace = true
-itertools.workspace = true
 
 # workspace
 openvm-chainspec.workspace = true
-openvm-mpt.workspace = true
+openvm-mpt = { workspace = true, features = ["witness"] }
 openvm-revm-crypto = { workspace = true, optional = true }
 
 # reth

--- a/crates/stateless-executor/src/error.rs
+++ b/crates/stateless-executor/src/error.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::crypto::RecoveryError;
-use alloy_primitives::BlockNumber;
+use openvm_mpt::witness::WitnessError;
 use reth_consensus::ConsensusError;
 use reth_evm::block::BlockExecutionError;
 use revm_primitives::B256;
@@ -12,11 +12,8 @@ pub enum StatelessExecutorError {
     #[error("parent storage root mismatch on hashed account {hashed_account}: got {actual}, expected {expected}")]
     ParentStorageRootMismatch { hashed_account: B256, actual: B256, expected: B256 },
 
-    #[error("non-consecutive block headers: parent block number {parent_block_number}, child block number {child_block_number}")]
-    NonConsecutiveBlockHeaders { parent_block_number: BlockNumber, child_block_number: BlockNumber },
-
-    #[error("parent block hash mismatch at block number {parent_block_number}: expected {expected}, got {actual}")]
-    ParentBlockHashMismatch { parent_block_number: BlockNumber, expected: B256, actual: B256 },
+    #[error(transparent)]
+    Witness(#[from] WitnessError),
 
     #[error("failed to recover block sender: {0}")]
     BlockSenderRecoveryError(#[from] RecoveryError),

--- a/crates/stateless-executor/src/io.rs
+++ b/crates/stateless-executor/src/io.rs
@@ -5,15 +5,14 @@ use alloy_consensus::Header;
 use alloy_rlp::{Decodable, Encodable};
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
 use bumpalo::Bump;
-use itertools::Itertools;
 use openvm_mpt::{EthereumState, EthereumStateBytes, Mpt};
+// `WitnessDb` and `WitnessInput` now live in `openvm-mpt` (behind its `witness` feature) so they
+// can be reused without copying. Re-exported here to preserve the `io::{WitnessDb, WitnessInput}`
+// path.
+pub use openvm_mpt::witness::{WitnessDb, WitnessInput};
 use reth_ethereum_primitives::Block;
-use reth_evm::execute::ProviderError;
-use revm::{
-    state::{AccountInfo, Bytecode},
-    DatabaseRef,
-};
-use revm_primitives::{keccak256, map::DefaultHashBuilder, Address, HashMap, B256, U256};
+use revm::state::Bytecode;
+use revm_primitives::{map::DefaultHashBuilder, HashMap, B256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -187,7 +186,7 @@ impl<'a> StatelessExecutorInputWithState<'a> {
 
     /// Creates a [`WitnessDb`].
     pub fn witness_db(&self) -> Result<WitnessDb<'a, '_>, StatelessExecutorError> {
-        <Self as WitnessInput>::witness_db(self)
+        Ok(<Self as WitnessInput>::witness_db(self)?)
     }
 }
 
@@ -215,149 +214,5 @@ impl<'a> WitnessInput<'a> for StatelessExecutorInputWithState<'a> {
     #[inline(always)]
     fn headers_len(&self) -> usize {
         1 + self.input.ancestor_headers.len()
-    }
-}
-
-/// A trait for constructing [`WitnessDb`]. The lifetime parameter `'a` is the lifetime of the
-/// bump arena backing the state's tries.
-pub trait WitnessInput<'a> {
-    /// Gets a reference to the state from which account info and storage slots are loaded.
-    fn state(&self) -> &EthereumState<'a>;
-
-    /// Gets the state trie root hash that the state referenced by
-    /// [state()](trait.WitnessInput#tymethod.state) must conform to.
-    fn state_anchor(&self) -> B256;
-
-    /// Gets an iterator over account bytecodes.
-    fn bytecodes(&self) -> impl Iterator<Item = &Bytecode>;
-
-    /// Gets an iterator over references to a consecutive, reverse-chronological block headers
-    /// starting from the current block header.
-    fn headers(&self) -> impl Iterator<Item = &Header>;
-
-    /// Gets the number of headers.
-    fn headers_len(&self) -> usize;
-
-    /// Creates a [`WitnessDb`] from a [`WitnessInput`] implementation. To do so, it verifies the
-    /// state root, ancestor headers and account bytecodes, and constructs the account and
-    /// storage values by reading against state tries.
-    ///
-    /// NOTE: For some unknown reasons, calling this trait method directly from outside of the type
-    /// implementing this trait causes a zkVM run to cost over 5M cycles more. To avoid this, define
-    /// a method inside the type that calls this trait method instead.
-    #[inline(always)]
-    fn witness_db(&self) -> Result<WitnessDb<'a, '_>, StatelessExecutorError> {
-        let state = self.state();
-
-        let bytecode_by_hash =
-            self.bytecodes().map(|code| (code.hash_slow(), code)).collect::<HashMap<_, _>>();
-
-        // Verify and build block hashes
-        let mut block_hashes: HashMap<u64, B256, _> =
-            HashMap::with_capacity_and_hasher(self.headers_len(), DefaultHashBuilder::default());
-        for (child_header, parent_header) in self.headers().tuple_windows() {
-            if parent_header.number != child_header.number - 1 {
-                return Err(StatelessExecutorError::NonConsecutiveBlockHeaders {
-                    parent_block_number: parent_header.number,
-                    child_block_number: child_header.number,
-                });
-            }
-
-            if parent_header.hash_slow() != child_header.parent_hash {
-                return Err(StatelessExecutorError::ParentBlockHashMismatch {
-                    parent_block_number: parent_header.number,
-                    expected: parent_header.hash_slow(),
-                    actual: child_header.parent_hash,
-                });
-            }
-
-            block_hashes.insert(parent_header.number, child_header.parent_hash);
-        }
-
-        Ok(WitnessDb { inner: state, block_hashes, bytecode_by_hash })
-    }
-}
-
-/// A database that loads account info and storage slots from a borrowed [`EthereumState`]. The
-/// lifetime parameter `'a` is the lifetime of the bump arena backing the state's tries, and `'b`
-/// is the lifetime of the borrows of the state and bytecodes.
-#[derive(Debug)]
-pub struct WitnessDb<'a, 'b> {
-    inner: &'b EthereumState<'a>,
-    block_hashes: HashMap<u64, B256>,
-    bytecode_by_hash: HashMap<B256, &'b Bytecode>,
-}
-
-impl<'a, 'b> WitnessDb<'a, 'b> {
-    pub fn new(
-        inner: &'b EthereumState<'a>,
-        block_hashes: HashMap<u64, B256>,
-        bytecode_by_hash: HashMap<B256, &'b Bytecode>,
-    ) -> Self {
-        Self { inner, block_hashes, bytecode_by_hash }
-    }
-}
-
-fn trie_error_to_provider_error(trie_error: openvm_mpt::Error) -> ProviderError {
-    match trie_error {
-        openvm_mpt::Error::RlpError(error) => ProviderError::Rlp(error),
-        _ => ProviderError::TrieWitnessError(trie_error.to_string()),
-    }
-}
-
-impl DatabaseRef for WitnessDb<'_, '_> {
-    /// The database error type.
-    type Error = ProviderError;
-
-    /// Get basic account information.
-    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let hashed_address = keccak256(address);
-
-        let account_in_trie = self
-            .inner
-            .state_trie
-            .get_rlp::<TrieAccount>(hashed_address.as_slice())
-            .map_err(trie_error_to_provider_error)?;
-
-        let account = account_in_trie.map(|account_in_trie| AccountInfo {
-            balance: account_in_trie.balance,
-            nonce: account_in_trie.nonce,
-            code_hash: account_in_trie.code_hash,
-            code: None,
-            account_id: None,
-        });
-
-        Ok(account)
-    }
-
-    /// Get account code by its hash.
-    fn code_by_hash_ref(&self, hash: B256) -> Result<Bytecode, Self::Error> {
-        // Cloning here is fine as `Bytes` is cheap to clone.
-        self.bytecode_by_hash.get(&hash).map(|code| (*code).clone()).ok_or_else(|| {
-            ProviderError::TrieWitnessError(format!("bytecode for {hash} not found"))
-        })
-    }
-
-    /// Get storage value of address at index.
-    ///
-    /// Returns `U256::ZERO` if the slot is not found in the trie.
-    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let hashed_address = keccak256(address);
-
-        let storage_trie = self.inner.storage_tries.get(&hashed_address).ok_or_else(|| {
-            ProviderError::TrieWitnessError(format!("storage trie for {address} not found"))
-        })?;
-
-        let hashed_slot = keccak256(index.to_be_bytes::<32>());
-        let storage_value = storage_trie
-            .get_rlp::<U256>(hashed_slot.as_slice())
-            .map_err(trie_error_to_provider_error)?
-            .unwrap_or_default();
-        Ok(storage_value)
-    }
-
-    /// Get block hash by block number.
-    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
-        self.block_hashes.get(&number).copied().ok_or(ProviderError::StateForNumberNotFound(number))
     }
 }


### PR DESCRIPTION
## What

Moves `WitnessDb`, `WitnessInput` and the ancestor-header-chain validation out of `openvm-stateless-executor`'s `io.rs` into a new **feature-gated `witness` module in `openvm-mpt`**, so downstream executors can *reuse* them instead of copying.

These types are already generic over the input (`WitnessDb` holds only a borrowed `EthereumState` + block-hash/bytecode maps; `WitnessInput` is a trait). The only thing tying them to `openvm-stateless-executor` was their location. Downstreams that build on `openvm-mpt` but define their own `StatelessExecutorInput` (e.g. LighterEVM, which forks this executor for custom block/tx/receipt primitives) currently hand-copy this ~140-line block — and drift from it (an upstream `Box::leak` fix and the `DatabaseRef` error-handling hardening both silently failed to propagate to the fork).

## Changes

- **`openvm-mpt`**: new `witness` module (`WitnessDb`, `WitnessInput`, `WitnessError`). Gated behind a new `witness` cargo feature so lean MPT consumers don't pull `reth-evm`/`alloy-consensus`/`itertools`.
- The two header-validation errors (`NonConsecutiveBlockHeaders`, `ParentBlockHashMismatch`) move into a dedicated `openvm_mpt::witness::WitnessError`.
- **`openvm-stateless-executor`**: enables `openvm-mpt/witness`, re-exports `io::{WitnessDb, WitnessInput}` for path compatibility, and its `StatelessExecutorError` gains `#[from] WitnessError`. Its own `WitnessInput` impl for `StatelessExecutorInputWithState` is unchanged.

This is a **pure relocation** — no logic changes to the witness DB or header validation. Existing `openvm_stateless_executor::io::{WitnessDb, WitnessInput}` paths still resolve via the re-export.

## Why gated

`WitnessDb`'s `DatabaseRef::Error = ProviderError` needs `reth-evm`, and `WitnessInput` needs `alloy_consensus::Header`. Putting the module behind `witness` (off by default) keeps `openvm-mpt`'s default build free of those deps. The guest and stateless executor already carry `reth-evm`, so no new cost for them.

## Benchmarks

Because this is a byte-identical move of the witness-DB and header-validation code, no execution-cycle or throughput delta is possible by construction.

A CI comparison was run anyway to confirm — `compare-branches.yml`, `execute-host` mode, block 23992138, base `develop-v2.0.0-rc.3` vs `valery/mpt-witness-db` ([run 28864494134](https://github.com/axiom-crypto/openvm-eth/actions/runs/28864494134)). Both the base and target jobs compiled and ran the reth benchmark successfully; the run's only failure was the shared **Upload Benchmark Metrics** step, which failed **identically for both base and target** (a bench-infra issue with the metrics endpoint, not branch- or code-specific), so `compare-results` was skipped and no automated table was produced.
