### PR TITLE
perf: traverse trie keys with a nibble cursor instead of materializing nibbles

### DIFF
--- a/crates/mpt/src/hp.rs
+++ b/crates/mpt/src/hp.rs
@@ -1,5 +1,5 @@
 //! Hex-prefix (HP) helpers and nibble utilities for MPT paths.
-use core::{cmp, iter};
+use core::cmp;
 use smallvec::SmallVec;
 
 /// Compact vector for nibble sequences used in key traversal.
@@ -7,30 +7,77 @@ pub(crate) type Nibbles = SmallVec<[u8; 64]>;
 
 // Hex-prefix (HP) encoding flags for MPT paths
 pub(crate) const HP_FLAG_ODD: u8 = 0x10; // path has odd number of nibbles; low nibble of first byte is data
-#[allow(dead_code)]
 pub(crate) const HP_FLAG_LEAF: u8 = 0x20; // node is a leaf (vs extension)
 
-/// Returns the length of the common prefix (in nibbles) between two nibble slices.
+/// A cursor over the nibbles of a lookup key. Trie traversal tracks a nibble offset into the raw
+/// key bytes and computes nibbles by shift/mask on demand, instead of materializing the nibble
+/// array up front.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct KeyNibbles<'k> {
+    key: &'k [u8],
+    /// Position of the cursor, in nibbles from the start of `key`.
+    offset: usize,
+}
+
+impl<'k> KeyNibbles<'k> {
+    #[inline(always)]
+    pub(crate) fn new(key: &'k [u8]) -> Self {
+        Self { key, offset: 0 }
+    }
+
+    /// Number of nibbles remaining after the cursor. Since the key is a whole number of bytes,
+    /// this always has the same parity as `offset`.
+    #[inline(always)]
+    pub(crate) fn remaining(&self) -> usize {
+        2 * self.key.len() - self.offset
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    /// The `i`-th nibble after the cursor.
+    #[inline(always)]
+    pub(crate) fn nib(&self, i: usize) -> u8 {
+        let j = self.offset + i;
+        let byte = self.key[j / 2];
+        if j % 2 == 0 {
+            byte >> 4
+        } else {
+            byte & 0x0f
+        }
+    }
+
+    /// Splits off the first nibble, like `slice::split_first`.
+    #[inline(always)]
+    pub(crate) fn split_first(&self) -> Option<(u8, Self)> {
+        if self.is_empty() {
+            None
+        } else {
+            Some((self.nib(0), self.advanced(1)))
+        }
+    }
+
+    /// The cursor advanced by `n` nibbles.
+    #[inline(always)]
+    pub(crate) fn advanced(&self, n: usize) -> Self {
+        debug_assert!(n <= self.remaining());
+        Self { key: self.key, offset: self.offset + n }
+    }
+}
+
+/// Returns the length of the common prefix (in nibbles) between a nibble slice and the key
+/// nibbles at the cursor.
 #[inline]
-pub(crate) fn lcp(a: &[u8], b: &[u8]) -> usize {
-    for (i, (a, b)) in iter::zip(a, b).enumerate() {
-        if a != b {
+pub(crate) fn lcp_key(nibs: &[u8], key: KeyNibbles<'_>) -> usize {
+    let max = cmp::min(nibs.len(), key.remaining());
+    for (i, &nib) in nibs[..max].iter().enumerate() {
+        if nib != key.nib(i) {
             return i;
         }
     }
-    cmp::min(a.len(), b.len())
-}
-
-/// Converts a byte slice into a vector of nibbles.
-/// Uses `SmallVec` to avoid heap allocation for typical key sizes (≤32 bytes = 64 nibbles).
-#[inline]
-pub(crate) fn to_nibs(slice: &[u8]) -> Nibbles {
-    let mut result = SmallVec::with_capacity(2 * slice.len());
-    for byte in slice {
-        result.push(byte >> 4);
-        result.push(byte & 0x0f);
-    }
-    result
+    max
 }
 
 /// Decodes a compact hex-prefix-encoded path (as used in MPT leaf/extension nodes)
@@ -72,100 +119,99 @@ pub(crate) fn encoded_path_nibble_count(encoded_path: &[u8]) -> usize {
     2 * (encoded_path.len() - 1) + if is_odd { 1 } else { 0 }
 }
 
-/// Compares a compact hex-prefix path with a nibble slice for equality without allocating.
+/// Compares a compact hex-prefix path with the key nibbles at the cursor for equality, without
+/// allocating.
 #[inline]
-pub(crate) fn encoded_path_eq_nibs(encoded_path: &[u8], nibs: &[u8]) -> bool {
+pub(crate) fn encoded_path_eq_key(encoded_path: &[u8], key: KeyNibbles<'_>) -> bool {
     let nib_count = encoded_path_nibble_count(encoded_path);
-    if nib_count != nibs.len() {
+    if nib_count != key.remaining() {
         return false;
     }
+    encoded_path_matches_key(encoded_path, nib_count, key)
+}
+
+/// If `encoded_path` is a prefix of the key nibbles at the cursor, returns the cursor advanced
+/// past it.
+#[inline]
+pub(crate) fn encoded_path_strip_prefix_key<'k>(
+    encoded_path: &[u8],
+    key: KeyNibbles<'k>,
+) -> Option<KeyNibbles<'k>> {
+    let nib_count = encoded_path_nibble_count(encoded_path);
+    if nib_count > key.remaining() {
+        return None;
+    }
+    encoded_path_matches_key(encoded_path, nib_count, key).then(|| key.advanced(nib_count))
+}
+
+/// Whether the first `nib_count` key nibbles at the cursor equal the path's nibbles.
+///
+/// After the path's optional odd leading nibble its data is whole bytes, so a cursor that is
+/// byte-aligned there can be compared as a whole byte slice. That is always the case when the path
+/// spans the entire remaining key: a cursor's parity matches its remaining length's, and a path's
+/// parity matches its nibble count's, so equal lengths force equal parity. Only a path shorter
+/// than the remaining key — an extension — can land misaligned and need the nibble-wise loop.
+#[inline]
+fn encoded_path_matches_key(encoded_path: &[u8], nib_count: usize, key: KeyNibbles<'_>) -> bool {
+    debug_assert!(nib_count <= key.remaining(), "caller must bound the path by the key");
     if nib_count == 0 {
         return true;
     }
 
     let first = encoded_path[0];
     let is_odd = (first & HP_FLAG_ODD) != 0;
-    let mut i = 0usize; // index in nibs
-    let mut j = 1usize; // index in encoded_path bytes
-
-    if is_odd {
-        if nibs[i] != (first & 0x0f) {
-            return false;
-        }
-        i += 1;
+    let start = usize::from(is_odd);
+    if is_odd && key.nib(0) != (first & 0x0f) {
+        return false;
     }
 
-    while i + 1 < nibs.len() {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return false;
-        }
-        if nibs[i + 1] != (b & 0x0f) {
-            return false;
-        }
-        i += 2;
-        j += 1;
+    let path_data = &encoded_path[1..];
+    if (key.offset + start) % 2 == 0 {
+        let key_start = (key.offset + start) / 2;
+        return key.key[key_start..key_start + path_data.len()] == *path_data;
     }
 
-    if i < nibs.len() {
-        // one last high nibble remains
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
+    // The path's byte boundaries are misaligned with the key's (possible for extension paths);
+    // compare nibble by nibble.
+    for (j, &byte) in path_data.iter().enumerate() {
+        let i = start + 2 * j;
+        if key.nib(i) != (byte >> 4) || key.nib(i + 1) != (byte & 0x0f) {
             return false;
         }
     }
     true
 }
 
-/// If `encoded_path` is a prefix of `nibs`, returns the tail `&nibs[matched_len..]`.
+/// Encodes the key nibbles remaining after the cursor into hex-prefix format in the bump arena.
+///
+/// The cursor's offset and its remaining length always share a parity, so after the encoding's
+/// optional odd leading nibble the cursor sits on a byte boundary and the rest of the path is a
+/// direct copy of the key's remaining bytes. See [`to_encoded_path_with_bump`] for paths rebuilt
+/// from a stored node's nibbles, which have no such alignment to exploit.
 #[inline]
-pub(crate) fn encoded_path_strip_prefix<'a>(
-    encoded_path: &[u8],
-    nibs: &'a [u8],
-) -> Option<&'a [u8]> {
-    let nib_count = encoded_path_nibble_count(encoded_path);
-    if nib_count > nibs.len() {
-        return None;
-    }
-    if nib_count == 0 {
-        return Some(nibs);
-    }
+pub(crate) fn encoded_path_from_key<'a>(
+    bump: &'a bumpalo::Bump,
+    key: KeyNibbles<'_>,
+    is_leaf: bool,
+) -> &'a [u8] {
+    let remaining = key.remaining();
+    let is_odd = !remaining.is_multiple_of(2);
+    let start = usize::from(is_odd);
 
-    let first = encoded_path[0];
-    let is_odd = (first & HP_FLAG_ODD) != 0;
-    let mut i = 0usize; // index in nibs
-    let mut j = 1usize; // index in encoded_path bytes
-
+    let mut prefix = if is_leaf { HP_FLAG_LEAF } else { 0x00 };
     if is_odd {
-        if nibs[i] != (first & 0x0f) {
-            return None;
-        }
-        i += 1;
+        prefix |= HP_FLAG_ODD | key.nib(0);
     }
 
-    while i + 1 < nib_count {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return None;
-        }
-        if nibs[i + 1] != (b & 0x0f) {
-            return None;
-        }
-        i += 2;
-        j += 1;
-    }
-
-    if i < nib_count {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return None;
-        }
-        i += 1;
-    }
-    Some(&nibs[i..])
+    let encoded = bump.alloc_slice_fill_copy(1 + remaining / 2, 0);
+    encoded[0] = prefix;
+    encoded[1..].copy_from_slice(&key.key[(key.offset + start) / 2..]);
+    encoded
 }
 
-/// Encodes nibbles into the standard hex-prefix format directly into the bump arena.
+/// Encodes a materialized nibble sequence into the standard hex-prefix format directly into the
+/// bump arena. This is the form used for paths rebuilt from a stored node's nibbles; paths built
+/// from a lookup key go through [`encoded_path_from_key`], which needs no nibble array.
 #[inline]
 pub(crate) fn to_encoded_path_with_bump<'a>(
     bump: &'a bumpalo::Bump,
@@ -176,9 +222,9 @@ pub(crate) fn to_encoded_path_with_bump<'a>(
     let encoded_len = 1 + (nibs.len() / 2);
     let mut encoded = bumpalo::collections::Vec::with_capacity_in(encoded_len, bump);
 
-    let mut prefix = if is_leaf { 0x20 } else { 0x00 };
+    let mut prefix = if is_leaf { HP_FLAG_LEAF } else { 0x00 };
     if is_odd {
-        prefix |= 0x10;
+        prefix |= HP_FLAG_ODD;
         encoded.push(prefix | nibs[0]);
         for i in (1..nibs.len()).step_by(2) {
             encoded.push((nibs[i] << 4) | nibs[i + 1]);
@@ -191,32 +237,6 @@ pub(crate) fn to_encoded_path_with_bump<'a>(
     }
 
     encoded.into_bump_slice()
-}
-
-/// Encodes nibbles into the standard hex-prefix format.
-#[cfg(feature = "host")]
-#[allow(dead_code)]
-#[inline]
-pub(crate) fn to_encoded_path(nibs: &[u8], is_leaf: bool) -> Vec<u8> {
-    let is_odd = !nibs.len().is_multiple_of(2);
-    let encoded_len = 1 + (nibs.len() / 2);
-    let mut encoded = Vec::with_capacity(encoded_len);
-
-    let mut prefix = if is_leaf { 0x20 } else { 0x00 };
-    if is_odd {
-        prefix |= 0x10;
-        encoded.push(prefix | nibs[0]);
-        for i in (1..nibs.len()).step_by(2) {
-            encoded.push((nibs[i] << 4) | nibs[i + 1]);
-        }
-    } else {
-        encoded.push(prefix);
-        for i in (0..nibs.len()).step_by(2) {
-            encoded.push((nibs[i] << 4) | nibs[i + 1]);
-        }
-    }
-
-    encoded
 }
 
 #[cfg(test)]
@@ -232,19 +252,95 @@ mod tests {
         assert_eq!(encoded_path_nibble_count(&[0x00, 0xab, 0xcd]), 4);
     }
 
+    /// Collects the nibbles remaining after a cursor, for assertions.
+    fn nibs_of(key: KeyNibbles<'_>) -> Vec<u8> {
+        (0..key.remaining()).map(|i| key.nib(i)).collect()
+    }
+
+    #[test]
+    fn test_key_nibbles_cursor() {
+        let key = KeyNibbles::new(&[0x12, 0x34]);
+        assert_eq!(key.remaining(), 4);
+        assert_eq!(nibs_of(key), vec![1, 2, 3, 4]);
+
+        let (first, rest) = key.split_first().unwrap();
+        assert_eq!(first, 1);
+        assert_eq!(nibs_of(rest), vec![2, 3, 4]);
+
+        let empty = key.advanced(4);
+        assert!(empty.is_empty());
+        assert!(empty.split_first().is_none());
+    }
+
+    /// The byte-slice fast paths in `encoded_path_matches_key` and `encoded_path_from_key` rely on
+    /// this: a cursor into a whole number of bytes sits at an odd offset only when an odd number
+    /// of nibbles remains, so skipping a path's odd leading nibble always lands on a byte boundary.
+    #[test]
+    fn test_cursor_offset_and_remaining_share_parity() {
+        for key_len in 0..4usize {
+            let bytes = vec![0xab; key_len];
+            let key = KeyNibbles::new(&bytes);
+            for offset in 0..=2 * key_len {
+                assert_eq!(offset % 2, key.advanced(offset).remaining() % 2);
+            }
+        }
+    }
+
     #[test]
     fn test_eq_and_strip_prefix() {
         // path [1, 2, 3] as HP: ODD + EXT, first byte 0x10 | 0x1, then 0x23
         let path = [HP_FLAG_ODD | 0x01, 0x23];
-        let key = [1, 2, 3];
-        assert!(encoded_path_eq_nibs(&path, &key));
-        assert_eq!(encoded_path_strip_prefix(&path, &key), Some(&[][..]));
+        // key nibbles [1, 2, 3]: cursor at offset 1 into bytes [0x01, 0x23]
+        let key = KeyNibbles::new(&[0x01, 0x23]).advanced(1);
+        assert!(encoded_path_eq_key(&path, key));
+        assert!(encoded_path_strip_prefix_key(&path, key).unwrap().is_empty());
 
-        let key_longer = [1, 2, 3, 4, 5];
-        assert_eq!(encoded_path_strip_prefix(&path, &key_longer), Some(&key_longer[3..]));
+        // key nibbles [1, 2, 3, 4, 5]: cursor at offset 1 into bytes [0x01, 0x23, 0x45]
+        let key_longer = KeyNibbles::new(&[0x01, 0x23, 0x45]).advanced(1);
+        assert!(!encoded_path_eq_key(&path, key_longer));
+        let tail = encoded_path_strip_prefix_key(&path, key_longer).unwrap();
+        assert_eq!(nibs_of(tail), vec![4, 5]);
 
-        let key_mismatch = [1, 2, 4];
-        assert!(encoded_path_strip_prefix(&path, &key_mismatch).is_none());
+        // key nibbles [1, 2, 4]
+        let key_mismatch = KeyNibbles::new(&[0x01, 0x24]).advanced(1);
+        assert!(encoded_path_strip_prefix_key(&path, key_mismatch).is_none());
+
+        // even-length path [2, 3] against a misaligned (odd-offset) cursor
+        let even_path = [0x00, 0x23];
+        let key_misaligned = KeyNibbles::new(&[0x02, 0x34]).advanced(1);
+        let tail = encoded_path_strip_prefix_key(&even_path, key_misaligned).unwrap();
+        assert_eq!(nibs_of(tail), vec![4]);
+        assert!(encoded_path_strip_prefix_key(
+            &even_path,
+            KeyNibbles::new(&[0x02, 0x44]).advanced(1)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_encoded_path_from_key() {
+        let bump = bumpalo::Bump::new();
+
+        let key = KeyNibbles::new(&[0xab, 0xcd]);
+        // leaf with an even remainder
+        assert_eq!(encoded_path_from_key(&bump, key, true), &[0x20, 0xab, 0xcd]);
+        // extension with an odd remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(1), false), &[0x1b, 0xcd]);
+        // leaf with an odd remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(3), true), &[0x3d]);
+        // empty remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(4), true), &[0x20]);
+    }
+
+    #[test]
+    fn test_lcp_key() {
+        let key = KeyNibbles::new(&[0xab, 0xcd]);
+        assert_eq!(lcp_key(&[], key), 0);
+        assert_eq!(lcp_key(&[0xa], key), 1);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xd], key), 2);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xc, 0xd], key), 4);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xc, 0xd, 0xe], key), 4);
+        assert_eq!(lcp_key(&[0xb, 0xc], key.advanced(1)), 2);
     }
 
     #[test]
@@ -263,22 +359,5 @@ mod tests {
         // leaf node with an odd path length
         let nibbles = vec![0x0a, 0x0b, 0x0c];
         assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, true), vec![0x3a, 0xbc]);
-    }
-
-    #[test]
-    fn test_lcp() {
-        let cases = [
-            (vec![], vec![], 0),
-            (vec![0xa], vec![0xa], 1),
-            (vec![0xa, 0xb], vec![0xa, 0xc], 1),
-            (vec![0xa, 0xb], vec![0xa, 0xb], 2),
-            (vec![0xa, 0xb], vec![0xa, 0xb, 0xc], 2),
-            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc], 3),
-            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc, 0xd], 3),
-            (vec![0xa, 0xb, 0xc, 0xd], vec![0xa, 0xb, 0xc, 0xd], 4),
-        ];
-        for (a, b, cpl) in cases {
-            assert_eq!(lcp(&a, &b), cpl)
-        }
     }
 }

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -14,8 +14,8 @@ use smallvec::SmallVec;
 use crate::{
     bump_bufmut::BumpBytesMut,
     hp::{
-        encoded_path_eq_nibs, encoded_path_strip_prefix, lcp, prefix_to_nibs,
-        to_encoded_path_with_bump, to_nibs,
+        encoded_path_eq_key, encoded_path_from_key, encoded_path_strip_prefix_key, lcp_key,
+        prefix_to_nibs, to_encoded_path_with_bump, KeyNibbles,
     },
     node::{BranchChildren, NodeData, NodeId, NodeRef},
 };
@@ -594,7 +594,7 @@ impl<'a> Mpt<'a> {
     /// Retrieves the value associated with a given key in the trie.
     #[inline]
     pub fn get<'s>(&'s self, key: &[u8]) -> Result<Option<&'a [u8]>, Error> {
-        self.get_internal(self.root_id, &to_nibs(key))
+        self.get_internal(self.root_id, KeyNibbles::new(key))
     }
 
     /// Retrieves the RLP-decoded value corresponding to the key.
@@ -612,8 +612,7 @@ impl<'a> Mpt<'a> {
     /// Inserts a key-value pair into the trie.
     #[inline]
     pub fn insert(&mut self, key: &[u8], value: &'a [u8]) -> Result<bool, Error> {
-        let key_nibs = &to_nibs(key);
-        self.insert_internal(self.root_id, key_nibs, value)
+        self.insert_internal(self.root_id, KeyNibbles::new(key), value)
     }
 
     /// Inserts an RLP-encoded value into the trie.
@@ -634,8 +633,7 @@ impl<'a> Mpt<'a> {
     /// present, it returns `true`. Otherwise, it returns `false`.
     #[inline]
     pub fn delete(&mut self, key: &[u8]) -> Result<bool, Error> {
-        let key_nibs = &to_nibs(key);
-        self.delete_internal(self.root_id, key_nibs)
+        self.delete_internal(self.root_id, KeyNibbles::new(key))
     }
 
     #[inline]
@@ -703,12 +701,16 @@ impl<'a> Mpt<'a> {
     }
 
     #[inline]
-    fn get_internal(&self, node_id: NodeId, key_nibs: &[u8]) -> Result<Option<&'a [u8]>, Error> {
+    fn get_internal(
+        &self,
+        node_id: NodeId,
+        key: KeyNibbles<'_>,
+    ) -> Result<Option<&'a [u8]>, Error> {
         match &self.nodes[node_id as usize] {
             NodeData::Null => Ok(None),
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => self.get_internal(id, tail),
                         None => Ok(None),
                     }
@@ -718,7 +720,7 @@ impl<'a> Mpt<'a> {
             }
             NodeData::Leaf(path_bytes, value) => {
                 // Compare compact path to key nibbles without allocating
-                if encoded_path_eq_nibs(path_bytes, key_nibs) {
+                if encoded_path_eq_key(path_bytes, key) {
                     Ok(Some(value))
                 } else {
                     Ok(None)
@@ -726,7 +728,7 @@ impl<'a> Mpt<'a> {
             }
             NodeData::Extension(path_bytes, child_id) => {
                 // Strip compact path prefix without allocating
-                if let Some(tail) = encoded_path_strip_prefix(path_bytes, key_nibs) {
+                if let Some(tail) = encoded_path_strip_prefix_key(path_bytes, key) {
                     self.get_internal(*child_id, tail)
                 } else {
                     Ok(None)
@@ -740,23 +742,23 @@ impl<'a> Mpt<'a> {
     fn insert_internal(
         &mut self,
         node_id: NodeId,
-        key_nibs: &[u8],
+        key: KeyNibbles<'_>,
         value: &'a [u8],
     ) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => {
-                let path = to_encoded_path_with_bump(self.bump, key_nibs, true);
+                let path = encoded_path_from_key(self.bump, key, true);
                 self.nodes[node_id as usize] = NodeData::Leaf(path, value);
                 true
             }
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => self.insert_internal(id, tail, value)?,
                         None => {
-                            let path = to_encoded_path_with_bump(self.bump, tail, true);
+                            let path = encoded_path_from_key(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            children[*i as usize].set(Some(new_leaf_id));
+                            children[usize::from(i)].set(Some(new_leaf_id));
                             true
                         }
                     }
@@ -765,7 +767,7 @@ impl<'a> Mpt<'a> {
                 }
             }
             NodeData::Leaf(prefix, old_value) => {
-                if encoded_path_eq_nibs(prefix, key_nibs) {
+                if encoded_path_eq_key(prefix, key) {
                     // update the value if it is different
                     if old_value == value {
                         return Ok(false);
@@ -774,9 +776,9 @@ impl<'a> Mpt<'a> {
                     true
                 } else {
                     let self_nibs = prefix_to_nibs(prefix);
-                    let common_len = lcp(&self_nibs, key_nibs);
+                    let common_len = lcp_key(&self_nibs, key);
 
-                    if common_len == self_nibs.len() || common_len == key_nibs.len() {
+                    if common_len == self_nibs.len() || common_len == key.remaining() {
                         return Err(Error::ValueInBranch);
                     } else {
                         // otherwise, create a branch with two children
@@ -788,11 +790,11 @@ impl<'a> Mpt<'a> {
                         let leaf1_id = self.add_node(NodeData::Leaf(leaf1_path, old_value), None);
 
                         let leaf2_path =
-                            to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                            encoded_path_from_key(self.bump, key.advanced(split_point), true);
                         let leaf2_id = self.add_node(NodeData::Leaf(leaf2_path, value), None);
 
                         children[self_nibs[common_len] as usize] = Some(leaf1_id);
-                        children[key_nibs[common_len] as usize] = Some(leaf2_id);
+                        children[usize::from(key.nib(common_len))] = Some(leaf2_id);
 
                         let branch_children = self.alloc_branch(children);
                         let new_node_data = if common_len > 0 {
@@ -813,13 +815,13 @@ impl<'a> Mpt<'a> {
                 }
             }
             NodeData::Extension(prefix, child_id) => {
-                if let Some(tail) = encoded_path_strip_prefix(prefix, key_nibs) {
+                if let Some(tail) = encoded_path_strip_prefix_key(prefix, key) {
                     self.insert_internal(child_id, tail, value)?
                 } else {
                     let self_nibs = prefix_to_nibs(prefix);
-                    let common_len = lcp(&self_nibs, key_nibs);
+                    let common_len = lcp_key(&self_nibs, key);
 
-                    if common_len == key_nibs.len() {
+                    if common_len == key.remaining() {
                         return Err(Error::ValueInBranch);
                     }
                     let split_point = common_len + 1;
@@ -835,9 +837,9 @@ impl<'a> Mpt<'a> {
                     }
 
                     let leaf_path =
-                        to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                        encoded_path_from_key(self.bump, key.advanced(split_point), true);
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
-                    children[key_nibs[common_len] as usize] = Some(leaf_id);
+                    children[usize::from(key.nib(common_len))] = Some(leaf_id);
 
                     let branch_children = self.alloc_branch(children);
                     let new_node_data = if common_len > 0 {
@@ -865,12 +867,12 @@ impl<'a> Mpt<'a> {
     }
 
     #[inline]
-    fn delete_internal(&mut self, node_id: NodeId, key_nibs: &[u8]) -> Result<bool, Error> {
+    fn delete_internal(&mut self, node_id: NodeId, key: KeyNibbles<'_>) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => false,
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => {
                             if !self.delete_internal(id, tail)? {
                                 return Ok(false);
@@ -878,7 +880,7 @@ impl<'a> Mpt<'a> {
 
                             // if the node is now empty, remove it
                             if matches!(self.nodes[id as usize], NodeData::Null) {
-                                children[*i as usize].set(None);
+                                children[usize::from(i)].set(None);
                             }
                         }
                         None => return Ok(false),
@@ -935,14 +937,14 @@ impl<'a> Mpt<'a> {
                 true
             }
             NodeData::Leaf(prefix, _) => {
-                if !encoded_path_eq_nibs(prefix, key_nibs) {
+                if !encoded_path_eq_key(prefix, key) {
                     return Ok(false);
                 }
                 self.nodes[node_id as usize] = NodeData::Null;
                 true
             }
             NodeData::Extension(prefix, child_id) => {
-                let tail = match encoded_path_strip_prefix(prefix, key_nibs) {
+                let tail = match encoded_path_strip_prefix_key(prefix, key) {
                     Some(tail) => tail,
                     None => return Ok(false),
                 };


### PR DESCRIPTION
Every `get`/`insert`/`delete` converted its key into a 64-nibble `SmallVec` up front (~64 bounds-checked pushes per operation), leaf comparison walked nibble by nibble, and new leaf paths were packed nibble by nibble — across the tens of thousands of trie operations in a block this adds up to a significant share of guest instructions.

Traversal now uses a `KeyNibbles` cursor: a `(key bytes, nibble offset)` pair that computes nibbles by shift/mask on demand.

- No nibble array is ever materialized for the key; branch steps just advance the offset.
- Path comparison exploits an alignment property of the cursor. Because a key is a whole number of bytes, a cursor's offset and its remaining length always share a parity — so skipping a path's optional odd leading nibble always lands on a byte boundary, and the rest of the path can be compared as a byte slice. A leaf path spans the entire remaining key, so equal lengths force equal parity and **leaf comparison always takes that path**. Only an extension, whose path is shorter than the remaining key, can land misaligned and fall back to comparing nibble by nibble.
- New leaf paths built from key suffixes (`encoded_path_from_key`) are a one-byte prefix plus a direct copy of the key's remaining bytes, instead of a nibble-packing loop.

Node-path operations (`prefix_to_nibs`, split/merge path construction) are unchanged — they operate on stored node paths, not lookup keys, and have no such alignment to exploit.

## Benchmark results

Block 24001988, execute-metered, [`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30340549147):

| metric | `develop-v2.1.0` | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 588,618,511 | 574,453,920 | **−14,164,591 (−2.406%)** |
| `metered_rows_unpadded` | 844,070,559 | 824,046,497 | −20,024,062 (−2.372%) |
| `metered_main_cells_unpadded` | 43,260,383,096 | 42,872,670,780 | −387,712,316 (−0.896%) |
| `metered_interaction_cells_unpadded` | 13,194,454,796 | 12,950,922,566 | −243,532,230 (−1.846%) |
| `metered_memory_unpadded_bytes` | 713,961,114,662 | 708,107,444,291 | −5,853,670,371 (−0.820%) |
| app segments | 65 | 63 | **−2** |
