### PR TITLE
test: cover P256VERIFY (secp256r1) precompile

### DIFF
--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -593,6 +593,32 @@ fn encode_bls_g2_point(point: &bls::G2Affine) -> [u8; BLS_G2_LEN] {
 mod tests {
     use super::*;
 
+    /// Runs `secp256r1_verify_signature` on a 160-byte P256VERIFY input (msg || sig || pk).
+    fn p256_verify_input(input_hex: &str) -> bool {
+        let input = alloy_primitives::hex::decode(input_hex).unwrap();
+        assert_eq!(input.len(), 160);
+        OpenVmCrypto.secp256r1_verify_signature(
+            input[..32].try_into().unwrap(),
+            input[32..96].try_into().unwrap(),
+            input[96..160].try_into().unwrap(),
+        )
+    }
+
+    // Test vectors from https://github.com/daimo-eth/p256-verifier/tree/master/test-vectors,
+    // as used by revm-precompile's secp256r1 tests.
+    #[test]
+    fn test_secp256r1_verify_signature() {
+        // valid signature
+        assert!(p256_verify_input("4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"));
+        assert!(p256_verify_input("3fec5769b5cf4e310a7d150508e82fb8e3eda1c2c94c61492d3bd8aea99e06c9e22466e928fdccef0de49e3503d2657d00494a00e764fd437bdafa05f5922b1fbbb77c6817ccf50748419477e843d5bac67e6a70e97dde5a57e0c983b777e1ad31a80482dadf89de6302b1988c82c29544c9c07bb910596158f6062517eb089a2f54c9a0f348752950094d3228d3b940258c75fe2a413cb70baa21dc2e352fc5"));
+        // wrong message
+        assert!(!p256_verify_input("3cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"));
+        // signature values out of range
+        assert!(!p256_verify_input("4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"));
+        // public key not on the curve
+        assert!(!p256_verify_input("4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+    }
+
     /// BN254 Fr modulus in big-endian bytes
     fn bn254_fr_modulus_be() -> Vec<u8> {
         let m = bn::Scalar::MODULUS;


### PR DESCRIPTION
The accelerated secp256r1 (P256VERIFY) hook was merged in #640. This adds the daimo p256-verifier test vectors (valid signature, wrong message, out-of-range signature values, public key off the curve) that #640 did not include, exercised against `OpenVmCrypto::secp256r1_verify_signature`.

The −9.34% instruction win originally measured on this branch is now delivered by #640; this PR is test coverage only.