### PR TITLE
perf: inline slice comparisons in trie decoding

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -101,6 +101,23 @@ unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
     bytes
 }
 
+/// Whether `slice` is the RLP encoding of an empty node reference: a single `EMPTY_STRING_CODE`
+/// byte. Written as an explicit pattern match because comparing against [`NULL_NODE_REF_SLICE`]
+/// with `==` compiles to a `memcmp` call, whose overhead dwarfs this one-byte check — and trie
+/// decoding performs it for every branch child.
+#[inline(always)]
+fn is_null_ref(slice: &[u8]) -> bool {
+    matches!(slice, [byte] if *byte == alloy_rlp::EMPTY_STRING_CODE)
+}
+
+/// Byte-slice equality as an explicit loop. Slice `==` compiles to a `memcmp` call; the node
+/// references compared during decoding are at most 33 bytes, where the call overhead dominates
+/// an inline loop.
+#[inline(always)]
+fn bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len() && std::iter::zip(a, b).all(|(x, y)| x == y)
+}
+
 /// Writes an RLP header with the given base code (`EMPTY_LIST_CODE` for lists,
 /// `EMPTY_STRING_CODE` for strings). Emits the same bytes as [`alloy_rlp::Header::encode`], but
 /// is generic over the output buffer: `alloy_rlp` encoding goes through `&mut dyn BufMut`, and
@@ -244,18 +261,18 @@ impl<'a> Mpt<'a> {
         // calculate node's reference and ensure it matches the `expected_node_ref` from parent.
         let node_ref = {
             if rlp_node_length < 32 {
-                if rlp_node != expected_node_ref.as_slice() {
+                if !bytes_eq(rlp_node, expected_node_ref.as_slice()) {
                     return Err(Error::NodeRefMismatch);
                 }
                 NodeRef::Bytes(rlp_node)
             } else if payload_length == 32 && !list {
-                if payload != expected_node_ref.as_slice() {
+                if !bytes_eq(payload, expected_node_ref.as_slice()) {
                     return Err(Error::NodeRefMismatch);
                 }
                 expected_node_ref
             } else {
                 let digest = keccak256(rlp_node);
-                if digest != expected_node_ref.as_slice() {
+                if !bytes_eq(digest.as_slice(), expected_node_ref.as_slice()) {
                     return Err(Error::NodeRefMismatch);
                 }
                 expected_node_ref
@@ -311,7 +328,7 @@ impl<'a> Mpt<'a> {
         // branch
         let child0_expected_node_ref = NodeRef::from_rlp_slice(&item0_header_start[..item0_length]);
         let child0 = {
-            if child0_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+            if is_null_ref(child0_expected_node_ref.as_slice()) {
                 None
             } else {
                 Some(self.decode_trie_internal(bytes, child0_expected_node_ref)?)
@@ -320,7 +337,7 @@ impl<'a> Mpt<'a> {
 
         let child1_expected_node_ref = NodeRef::from_rlp_slice(&item1_header_start[..item1_length]);
         let child1 = {
-            if child1_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+            if is_null_ref(child1_expected_node_ref.as_slice()) {
                 None
             } else {
                 Some(self.decode_trie_internal(bytes, child1_expected_node_ref)?)
@@ -349,7 +366,7 @@ impl<'a> Mpt<'a> {
                 NodeRef::from_rlp_slice(&item_header_start[..item_length]);
 
             *child = MaybeUninit::new({
-                if child_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+                if is_null_ref(child_expected_node_ref.as_slice()) {
                     None
                 } else {
                     Some(self.decode_trie_internal(bytes, child_expected_node_ref)?)
@@ -363,7 +380,7 @@ impl<'a> Mpt<'a> {
             std::mem::transmute::<[MaybeUninit<Option<NodeId>>; 16], [Option<NodeId>; 16]>(childs)
         };
 
-        if payload != NULL_NODE_REF_SLICE {
+        if !is_null_ref(payload) {
             return Err(Error::ValueInBranch);
         }
 


### PR DESCRIPTION
Stacked on #647.

Guest circuit flamegraphs (run 28863610679, block 23992138) attributed 4.98% of all guest instructions (42.8M) to `memcmp` calls made from `decode_trie_internal`: every slice `==` in the decode loop compiles to a library `memcmp` call on rv32, and the hottest one compares a single byte against `NULL_NODE_REF_SLICE` — sixteen times per branch node. The call overhead (argument setup, jump, length dispatch) dwarfs the comparisons themselves, which are at most 33 bytes.

Two `#[inline(always)]` helpers replace the slice `==` uses on the decode path: `is_null_ref` (a one-byte pattern match) for the branch-child null checks and the branch value-slot check, and `bytes_eq` (an explicit byte loop) for the node-reference and digest verifications.

The host-only proof decoding path is unchanged.

## Benchmark results

Compare-branches run [28871053010](https://github.com/axiom-crypto/openvm-eth/actions/runs/28871053010) (block 23992138, prove-stark, g7e.2xlarge), base `valery/mpt-nibble-cursor` (#647):

| metric | base | this PR | delta |
|---|---:|---:|---:|
| execute_metered_insns | 842,309,778 | 815,665,374 | **−26,644,404 (−3.16%)** |
| rows | 1,551,750,310 | 1,500,080,438 | −3.33% |
| total_cells | 71,501,335,937 | 70,143,019,466 | −1.90% |
| app segments | 86 | 85 | −1 |
| total_proof_time_ms | 89,241 | 88,344 | −1.00% |
| reth-block_time_ms | 143,810 | 143,115 | −0.48% |

Wall-clock deltas are within single-run noise (±0.5–1%); instruction/row/cell counts are deterministic.
