### PR TITLE
perf: word-at-a-time memcmp/bcmp for the guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,6 +7342,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-guest-mem"
+version = "0.4.0"
+
+[[package]]
 name = "openvm-instructions"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=main#3ee99e5002e123a6ca50c815c3e40ab0bd96b0e3"
@@ -8085,6 +8089,7 @@ dependencies = [
  "bumpalo",
  "itertools 0.14.0",
  "openvm-chainspec",
+ "openvm-guest-mem",
  "openvm-mpt",
  "openvm-revm-crypto",
  "reth-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mpt",
     "crates/revm-crypto",
     "crates/stateless-executor",
+    "crates/guest-mem",
     "crates/chainspec",
     "crates/stateless-witness",
     "crates/mpt-tools",
@@ -64,6 +65,7 @@ openvm-curve-utils = { path = "./crates/curve-utils", default-features = false }
 openvm-kzg = { path = "./crates/kzg", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 openvm-revm-crypto = { path = "./crates/revm-crypto" }
+openvm-guest-mem = { path = "./crates/guest-mem" }
 openvm-stateless-executor = { path = "./crates/stateless-executor" }
 openvm-chainspec = { path = "./crates/chainspec" }
 # workspace (host only)

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2460,6 +2460,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-guest-mem"
+version = "0.4.0"
+
+[[package]]
 name = "openvm-keccak256"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=main#3ee99e5002e123a6ca50c815c3e40ab0bd96b0e3"
@@ -2626,6 +2630,7 @@ dependencies = [
  "bumpalo",
  "itertools 0.14.0",
  "openvm-chainspec",
+ "openvm-guest-mem",
  "openvm-mpt",
  "openvm-revm-crypto",
  "reth-consensus",

--- a/crates/guest-mem/Cargo.toml
+++ b/crates/guest-mem/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "openvm-guest-mem"
+description = "Optimized mem* routines for the OpenVM guest target"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/guest-mem/src/lib.rs
+++ b/crates/guest-mem/src/lib.rs
@@ -1,0 +1,126 @@
+//! Word-at-a-time `memcmp`/`bcmp` for the guest.
+//!
+//! `openvm` ships optimized `memcpy`/`memset` assembly, but `memcmp` falls
+//! back to compiler-builtins' byte-at-a-time loop, which costs several
+//! instructions per byte on rv32. Slice equality on byte-array types (`U256`
+//! words in the EVM interpreter, hashes, RLP node references) lowers to
+//! `memcmp`/`bcmp` calls, making this one of the hottest functions in the
+//! guest. The strong symbols defined here override compiler-builtins' weak
+//! definitions at link time.
+//!
+//! `#![no_builtins]` prevents LLVM from recognizing the comparison loop as a
+//! memcmp idiom and lowering it back into a `memcmp` libcall.
+
+#![no_std]
+#![no_builtins]
+
+// The word-compare path derives the first differing byte from the least
+// significant differing bits, which is only correct on little-endian targets.
+const _: () = assert!(cfg!(target_endian = "little"));
+
+const WORD: usize = core::mem::size_of::<usize>();
+
+/// Compares `n` bytes at `a` and `b` with C `memcmp` semantics, reading a
+/// word at a time when both pointers share the same alignment.
+///
+/// # Safety
+///
+/// `a` and `b` must be valid for reads of `n` bytes.
+pub unsafe fn compare_bytes(mut a: *const u8, mut b: *const u8, mut n: usize) -> i32 {
+    unsafe {
+        if a.addr() % WORD == b.addr() % WORD {
+            while a.addr() % WORD != 0 && n > 0 {
+                let (x, y) = (*a, *b);
+                if x != y {
+                    return i32::from(x) - i32::from(y);
+                }
+                a = a.add(1);
+                b = b.add(1);
+                n -= 1;
+            }
+            while n >= WORD {
+                let x = *a.cast::<usize>();
+                let y = *b.cast::<usize>();
+                if x != y {
+                    // Little-endian: the lowest differing byte address holds
+                    // the least significant differing byte of the word.
+                    let shift = ((x ^ y).trailing_zeros() / 8) * 8;
+                    return i32::from((x >> shift) as u8) - i32::from((y >> shift) as u8);
+                }
+                a = a.add(WORD);
+                b = b.add(WORD);
+                n -= WORD;
+            }
+        }
+        while n > 0 {
+            let (x, y) = (*a, *b);
+            if x != y {
+                return i32::from(x) - i32::from(y);
+            }
+            a = a.add(1);
+            b = b.add(1);
+            n -= 1;
+        }
+        0
+    }
+}
+
+#[cfg(target_os = "zkvm")]
+mod c_exports {
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn memcmp(a: *const u8, b: *const u8, n: usize) -> i32 {
+        unsafe { super::compare_bytes(a, b, n) }
+    }
+
+    // Equality-only variant of `memcmp`; the compiler emits calls to it for
+    // slice `==` where the ordering is unused.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn bcmp(a: *const u8, b: *const u8, n: usize) -> i32 {
+        unsafe { super::compare_bytes(a, b, n) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compare_bytes;
+
+    fn reference(a: &[u8], b: &[u8]) -> i32 {
+        for (x, y) in core::iter::zip(a, b) {
+            if x != y {
+                return i32::from(*x) - i32::from(*y);
+            }
+        }
+        0
+    }
+
+    #[test]
+    fn matches_reference_across_alignments_lengths_and_diff_positions() {
+        let mut base = [0u8; 96];
+        for (i, byte) in base.iter_mut().enumerate() {
+            *byte = (i * 37 % 251) as u8;
+        }
+        for a_off in 0..8 {
+            for b_off in 0..8 {
+                for len in 0..48 {
+                    let a = &base[a_off..a_off + len];
+                    let mut b_buf = [0u8; 96];
+                    b_buf[b_off..b_off + len].copy_from_slice(a);
+                    // diff_pos == len leaves the buffers equal.
+                    for diff_pos in 0..=len {
+                        let mut b_buf = b_buf;
+                        if diff_pos < len {
+                            b_buf[b_off + diff_pos] ^= 0x80;
+                        }
+                        let b = &b_buf[b_off..b_off + len];
+                        let got = unsafe { compare_bytes(a.as_ptr(), b.as_ptr(), len) };
+                        assert_eq!(
+                            got,
+                            reference(a, b),
+                            "a_off={a_off} b_off={b_off} len={len} diff_pos={diff_pos}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/stateless-executor/Cargo.toml
+++ b/crates/stateless-executor/Cargo.toml
@@ -41,6 +41,9 @@ alloy-consensus = { workspace = true, features = ["crypto-backend", "serde-binco
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
 
+[target.'cfg(target_os = "zkvm")'.dependencies]
+openvm-guest-mem.workspace = true
+
 [package.metadata.cargo-machete]
 ignored = ["reth-ethereum-primitives"]
 

--- a/crates/stateless-executor/src/lib.rs
+++ b/crates/stateless-executor/src/lib.rs
@@ -17,6 +17,11 @@ use reth_revm::db::CacheDB;
 
 use bumpalo::Bump;
 
+// Links the guest's optimized `memcmp`/`bcmp` overrides into every binary
+// that executes blocks inside the zkVM.
+#[cfg(target_os = "zkvm")]
+use openvm_guest_mem as _;
+
 use crate::{
     error::StatelessExecutorError,
     io::{StatelessExecutorInput, StatelessExecutorInputWithState},


### PR DESCRIPTION
Stacked on #649.

openvm ships optimized musl assembly for `memcpy`/`memset`, but not for `memcmp` — and musl has none to ship: its `memcmp` is a naive byte loop, and so is the compiler-builtins fallback that the guest actually links (~6 instructions per byte on rv32 including call overhead). Guest circuit flamegraphs (run 28863610679, block 23992138) showed 12.2% of all guest instructions inside `memcmp`; after #649 removed the trie-decode callers, the remainder (~7%) is dominated by `U256` equality under the EVM interpreter's `jumpi`/`iszero`/`eq`, plus hash and bytes compares.

This adds `openvm-guest-mem`, a `#![no_std]` `#![no_builtins]` crate exporting strong `memcmp`/`bcmp` symbols for `target_os = "zkvm"` that override compiler-builtins' weak definitions at link time — the same mechanism openvm's own `memcpy.s` uses. When both pointers are co-aligned, it compares a word at a time (7 instructions per 4 bytes, ~3.4x on aligned compares); otherwise it falls back to the byte loop. The word loop never over-reads and only issues aligned word loads. `stateless-executor` links it via a zkvm-only dependency, so every guest binary gets it.

The exported symbols keep exact C `memcmp` semantics (byte difference of the first mismatching byte). A host-side test sweeps all alignment x length x mismatch-position combinations against a reference implementation. Verified in the built guest ELF: a single `memcmp` symbol whose disassembly is the word loop.

**This is a candidate for upstreaming into openvm's toolchain crate next to `memcpy.s`, at which point this crate can be deleted.**

## Benchmark results

Single-branch run [28875243785](https://github.com/axiom-crypto/openvm-eth/actions/runs/28875243785) (block 23992138, prove-stark, g7e.2xlarge), compared against the `valery/mpt-inline-cmp` (#649) numbers from run [28871053010](https://github.com/axiom-crypto/openvm-eth/actions/runs/28871053010) — identical config, and instruction/row/cell counts are deterministic:

| metric | base (#649) | this PR | delta |
|---|---:|---:|---:|
| execute_metered_insns | 815,665,374 | 779,097,929 | **−36,567,445 (−4.48%)** |
| rows | 1,500,080,438 | 1,459,422,265 | −2.71% |
| total_cells | 70,143,019,466 | 68,187,523,763 | −2.79% |
| app segments | 85 | 83 | −2 |
| total_proof_time_ms | 88,344 | 84,309 | −4.57% |
| reth-block_time_ms | 143,115 | 138,375 | −3.31% |
