### PR TITLE
perf: shrink decode_trie update headroom to 1/16

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -203,20 +203,12 @@ impl<'a> Mpt<'a> {
             return Ok(Self::new(bump));
         }
 
-        // A growth factor applied to the node vector's capacity during deserialization.
-        // This is a pragmatic optimization to pre-allocate a buffer for nodes that will be
-        // added during the `update` phase. It prevents a "reallocation storm" where the
-        // main trie and dozens of storage tries all try to reallocate their full node
-        // vectors on the first update.
-        // TODO: this is imperfect solution and the constant is somewhat arbitrary (although
-        // reasonable)
-        //
-        // Simple improvement: run benchmark on a set of blocks (e.g. 100
-        // blocks) and select the best constant.
-        //
-        // More advanced improvement: either pre-execute block at guest to know exact allocations in
-        // advance, or allocate a separate arena specifically for updates.
-        let capacity = num_nodes + (num_nodes / 2);
+        // Headroom for nodes added during the update phase, so the node vectors almost never
+        // reallocate. Actual growth is tiny — measured on mainnet block 23992138, the state trie
+        // grew by 0.06% and the storage tries by 0.30% in total — so ~6% is ample margin, while
+        // a larger factor wastes peak guest memory, which drives the segment count. The `+ 4`
+        // covers small tries where the fractional headroom rounds to zero.
+        let capacity = num_nodes + num_nodes / 16 + 4;
         let mut trie = Self::with_capacity(bump, capacity);
 
         // construct the expected root reference


### PR DESCRIPTION
Stacked on #651.

`decode_trie` pre-allocated node vectors at 1.5x the witness node count as headroom for update-phase insertions. Measured on mainnet block 23992138 (via `mpt_profiler`'s data file and a host-side count), actual growth is two orders of magnitude smaller: the state trie grew by 0.06% and the 1,116 storage tries by 0.30% in total. This shrinks the headroom to 1/16 (~6%, still ~20x the observed growth) plus a small constant for tiny tries. If an outlier trie ever outgrows it, the vector reallocates normally — correctness is unaffected.

## Benchmark results — neutral

Single-branch run [28885171203](https://github.com/axiom-crypto/openvm-eth/actions/runs/28885171203), isolated against the #651 base (block 23992138, prove-stark, g7e.2xlarge):

| metric | base (#651) | this PR | delta |
|---|---:|---:|---:|
| execute_metered_insns | 779,703,953 | 779,747,497 | +43,544 (+0.006%) |
| total_cells | 68,062,443,267 | 68,049,467,139 | −12,976,128 (−0.019%) |
| app segments | 83 | 83 | 0 |

Within noise, and it does not drop a segment. The dhat measurement that motivated it was host (64-bit) heap; guest peak memory for this block is evidently not bound by the node-vector padding, so freeing it changes nothing here. Keeping this only as memory hygiene (removes a genuine 1.5x over-allocation and a stale `TODO`), not as a perf win — reasonable to close if we'd rather not carry a neutral change.
