### PR TITLE
perf: patch ruint to open-code U256 equality (avoids memcmp)

### DIFF
--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -3699,8 +3699,7 @@ dependencies = [
 [[package]]
 name = "ruint"
 version = "1.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+source = "git+https://github.com/qumeric/uint?branch=ruint-eq-1.17.2#cdd977d836e40857564b36c58a75bcd3be026267"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3727,8 +3726,7 @@ dependencies = [
 [[package]]
 name = "ruint-macro"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+source = "git+https://github.com/qumeric/uint?branch=ruint-eq-1.17.2#cdd977d836e40857564b36c58a75bcd3be026267"
 
 [[package]]
 name = "rustc-hash"

--- a/bin/stateless-guest/Cargo.toml
+++ b/bin/stateless-guest/Cargo.toml
@@ -41,3 +41,10 @@ strip = true
 inherits = "release"
 debug = 2
 strip = false
+
+# Open-codes `Uint` equality/`is_zero` so U256 comparisons stop lowering to a
+# `memcmp` libcall on rv32. Pending upstream (alloy-rs/ruint#604); replace with
+# a version bump once released. Pinned to a 1.17.2-based branch so it stays
+# semver-compatible with the guest's resolved `ruint` version.
+[patch.crates-io]
+ruint = { git = "https://github.com/qumeric/uint", branch = "ruint-eq-1.17.2" }


### PR DESCRIPTION
`ruint`'s `Uint` derives `PartialEq`, which compares the `[u64; LIMBS]` limb array; on rv32 that lowers to a `bcmp`/`memcmp` libcall. Full-stack guest flamegraphs attributed a large share of the remaining `memcmp` cost to U256 comparisons in the EVM interpreter (`JUMPI`/`ISZERO`/`EQ` and many smaller sites), and `is_zero` additionally materialized a `ZERO` on the stack just to compare against it.

This patches ruint (fork `qumeric/uint`, branched off the `v1.17.2` tag the guest resolves) to open-code `PartialEq` as a branchless limb XOR-accumulate and `is_zero` as a direct limb OR-accumulate. On x86/aarch64 this vectorizes to the same code as the derive; on rv32 it drops the libcall and its length-generic dispatch, and inlines a fixed 4-limb compare at every call site. All 119 upstream ruint tests pass on the fork.

An upstream PR to `recmo/uint` is here https://github.com/alloy-rs/ruint/pull/604.

I am not sure if we want to merge this PR or wait until it's merged to upstream.

## Benchmark results

Measured as the marginal gain **on top of the full six-PR stack** (which already includes the guest `memcmp` override #650), so this is the true additional win, not the inflated figure a bare-develop base would show. Single-branch run [28942176920](https://github.com/axiom-crypto/openvm-eth/actions/runs/28942176920) vs the all-opts base (block 23992138, prove-stark, g7e.2xlarge):

| metric | base (6 PRs) | + this patch | delta |
|---|---:|---:|---:|
| execute_metered_insns | 698,982,806 | 672,824,032 | **−26,158,774 (−3.74%)** |
| rows | 1,308,779,167 | 1,251,889,640 | −4.35% |
| total_cells | 63,352,511,270 | 61,582,827,847 | **−2.79%** |
| app segments | 76 | 73 | −3 |
| total_proof_time_ms | 77,832 | 76,058 | −2.28% |

U256 equality/`is_zero` turned out far more pervasive than the flamegraph's memcmp-self attribution suggested — the cost was spread across many small call sites plus the uncounted `is_zero` materialization overhead.
