### PR TITLE
chore: update default bench block to 24001988

### DIFF
--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -16,7 +16,7 @@ on:
         type: number
         required: false
         description: Ethereum block number
-        default: 23992138
+        default: 24001988
       benchmark_mode:
         type: choice
         required: false
@@ -54,7 +54,7 @@ jobs:
       OPENVM_REV: ${{ github.event.inputs.base_rev }}
       run_benchmark: true
       benchmark_mode: ${{ github.event.inputs.benchmark_mode }}
-      benchmark_block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '23992138') }}
+      benchmark_block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '24001988') }}
       instance_family: ${{ github.event.inputs.instance_family }}
     secrets: inherit
 
@@ -73,7 +73,7 @@ jobs:
     needs: patch-target
     with:
       mode: ${{ github.event.inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '24001988') }}
       instance_family: ${{ github.event.inputs.instance_family }}
       ref: ${{ needs.patch-target.outputs.branch_name }}
       tag: ${{ needs.patch-target.outputs.tag }}
@@ -87,7 +87,7 @@ jobs:
     needs: patch-target
     with:
       mode: ${{ github.event.inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '24001988') }}
       instance_family: ${{ github.event.inputs.instance_family }}
       ref: ${{ needs.patch-target.outputs.branch_name }}
       tag: ${{ needs.patch-target.outputs.tag }}
@@ -101,7 +101,7 @@ jobs:
     needs: patch-target
     with:
       mode: ${{ github.event.inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || github.event.inputs.block_number || '24001988') }}
       instance_family: ${{ github.event.inputs.instance_family }}
       ref: ${{ needs.patch-target.outputs.branch_name }}
       tag: ${{ needs.patch-target.outputs.tag }}

--- a/.github/workflows/compare-branches.yml
+++ b/.github/workflows/compare-branches.yml
@@ -17,7 +17,7 @@ on:
         type: number
         required: false
         description: Ethereum block number
-        default: 23992138
+        default: 24001988
       benchmark_mode:
         type: choice
         required: false
@@ -54,7 +54,7 @@ jobs:
     with:
       ref: ${{ inputs.base_ref }}
       mode: ${{ inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || '24001988') }}
       instance_family: ${{ inputs.instance_family }}
       profiling: none
     secrets: inherit
@@ -65,7 +65,7 @@ jobs:
     with:
       ref: ${{ inputs.target_ref }}
       mode: ${{ inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || '24001988') }}
       instance_family: ${{ inputs.instance_family }}
       profiling: none
     secrets: inherit
@@ -77,7 +77,7 @@ jobs:
     with:
       ref: ${{ inputs.target_ref }}
       mode: ${{ inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || '24001988') }}
       instance_family: ${{ inputs.instance_family }}
       profiling: host
     secrets: inherit
@@ -89,7 +89,7 @@ jobs:
     with:
       ref: ${{ inputs.target_ref }}
       mode: ${{ inputs.benchmark_mode }}
-      block_number: ${{ fromJSON(inputs.block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.block_number || '24001988') }}
       instance_family: ${{ inputs.instance_family }}
       profiling: guest
     secrets: inherit

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -8,7 +8,7 @@ on:
         type: number
         required: false
         description: Ethereum block number
-        default: 23992138
+        default: 24001988
       mode:
         type: choice
         required: false
@@ -104,7 +104,7 @@ on:
         type: number
         required: false
         description: Ethereum block number
-        default: 23992138
+        default: 24001988
       mode:
         type: string
         required: false

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -11,7 +11,7 @@ on:
         description: "Block number to generate input for"
         required: true
         type: string
-        default: "23992138"
+        default: "24001988"
       rerun_keygen:
         description: "Rerun keygen"
         required: false

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -38,7 +38,7 @@ on:
         description: "Block number to run the benchmark on"
         type: number
         required: false
-        default: 23992138
+        default: 24001988
   #schedule:
   #  - cron: "0 */12 * * *" # Run every 12 hours
   workflow_call:
@@ -80,7 +80,7 @@ on:
         type: number
         required: false
         description: "Block number to run the benchmark on"
-        default: 23992138
+        default: 24001988
       # https://github.com/actions/runner/discussions/1884
       manual_call:
         description: "To distinguish workflow_call from workflow_dispatch"
@@ -231,7 +231,7 @@ jobs:
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'g7e.2xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
-      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '24001988') }}
       profiling: none
     secrets: inherit
 
@@ -244,7 +244,7 @@ jobs:
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'm8g.24xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
-      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '24001988') }}
       profiling: host
     secrets: inherit
 
@@ -257,7 +257,7 @@ jobs:
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'm8g.24xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
-      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '23992138') }}
+      block_number: ${{ fromJSON(inputs.benchmark_block_number || github.event.inputs.benchmark_block_number || '24001988') }}
       profiling: guest
     secrets: inherit
 

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@
 #   --generate-vm-vkey  Shortcut for --mode generate-vm-vkey
 #   --profile <PROFILE> Set the Cargo build profile (default: profiling)
 #                       Valid profiles: dev, release, profiling
-#   --block <N>         Set the block number to prove (default: 23992138)
+#   --block <N>         Set the block number to prove (default: 24001988)
 #   --app-log-blowup <N>
 #   --app-l-skip <N>    Log of univariate skip domain size (default: 4)
 #   --leaf-log-blowup <N>
@@ -36,7 +36,7 @@
 #   ./run.sh --perf --mode execute         # Run with host profiling (Firefox Profiler link)
 #   ./run.sh --nsys --mode prove-app      # Run with nsys profiling
 #   ./run.sh --nsys --nsys-gpu-metrics --mode prove-app
-#   ./run.sh --block 23992138             # Prove a specific block
+#   ./run.sh --block 24001988             # Prove a specific block
 #   ./run.sh --mode generate-vm-vkey      # Generate reth.vm.vk locally
 #   ./run.sh --generate-vm-vkey           # Same as above (shortcut)
 #
@@ -252,7 +252,7 @@ case "${PROFILE_OVERRIDE:-release}" in
         ;;
 esac
 FEATURES="parallel,metrics,jemalloc,unprotected"
-BLOCK_NUMBER="${BLOCK_NUMBER_OVERRIDE:-23992138}"
+BLOCK_NUMBER="${BLOCK_NUMBER_OVERRIDE:-24001988}"
 TOOLCHAIN="+$RUST_TOOLCHAIN"
 BIN_NAME="openvm-reth-benchmark"
 export VPMM_PAGE_SIZE=$((4 << 20))


### PR DESCRIPTION
## Why

The current default block 23992138 was picked in December as a post-Fusaka p99 block (openvm-reth-benchmark#542). Tracing it shows it contains **7 P256VERIFY calls**, which at the time ran in software and accounted for ~8.3% of its instructions. In other words, it made the tail *because* of an inefficiency that #640 has since fixed — and its instruction mix over-represents p256 relative to typical blocks (0–2 calls). This is why #648's −9.34% single-block win did not move the 7200-block release percentiles at all.

## What

Default block is now **24001988**: the P100 of the 16-GPU release run over blocks 24000000..24007199 (7372ms, 123 segments, 60.0M gas across 65 txs). Its precompile usage is a single ecRecover — its slowness is structural (pure EVM compute), so its tail ranking is robust to precompile accelerations and it won't skew relative deltas the way a precompile-heavy block does.

Other candidates considered from the same run, if reviewers prefer a different point on the curve:
- 24004255 — p99 (6270ms, 79 segments), clean mix; closer to the old default's CI cost
- 24000855 — p50 (3794ms, 40 segments, 27.9M gas), clean; representative median block
- 24002549 / 24007141 — old tail #2/#5, dominated by modexp=277 + bn254=131 (Aztec pattern); useful as named stress blocks for modexp/bn254 work but deliberately not the default

Note: benches on the new default are ~30% slower than on 23992138 (123 vs 92 segments).