### PR TITLE
perf: shrink branch child slots to 4 bytes via NonZero node ids

### DIFF
--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -1,11 +1,16 @@
-use core::cell::Cell;
+use core::{cell::Cell, num::NonZeroU32};
 
 use revm_primitives::hex;
 
 pub(crate) type NodeId = u32;
 
+/// Id of a branch child node. `NonZero` so that a child slot (`Option<BranchChildId>`) fits in
+/// 4 bytes — `Option<u32>` has no niche and takes 8. Node id 0 is the null-node sentinel
+/// (`NULL_NODE_ID`) and is never stored as a branch child.
+pub(crate) type BranchChildId = NonZeroU32;
+
 /// Children slots of a branch node, allocated in the trie's bump arena.
-pub(crate) type BranchChildren<'a> = &'a [Cell<Option<NodeId>>; 16];
+pub(crate) type BranchChildren<'a> = &'a [Cell<Option<BranchChildId>>; 16];
 
 /// Node data for arena-based trie with zero-copy optimization.
 ///

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    node::{NodeData, NodeId},
+    node::{BranchChildId, NodeData, NodeId},
     trie::{NULL_NODE_ID, NULL_NODE_REF_SLICE},
     Error, Mpt,
 };
@@ -77,10 +77,11 @@ impl MptResolver {
                         return Err(Error::ValueInBranch);
                     }
 
-                    let mut childs: [Option<NodeId>; 16] = Default::default();
+                    let mut childs: [Option<BranchChildId>; 16] = Default::default();
                     for (i, mut item) in items.into_iter().take(16).enumerate() {
                         let child_id = self.resolve_internal(&mut item, mpt)?;
-                        childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
+                        // `BranchChildId::new` maps the `NULL_NODE_ID` sentinel (0) to `None`.
+                        childs[i] = BranchChildId::new(child_id);
                     }
                     // The children array is allocated in `mpt`'s own bump, so no copy is needed.
                     let children = mpt.alloc_branch(childs);

--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -1,6 +1,9 @@
 use revm_primitives::{b256, keccak256, B256};
 
-use crate::{node::NodeData, Error, Mpt};
+use crate::{
+    node::{BranchChildId, NodeData},
+    Error, Mpt,
+};
 
 trait RlpBytes {
     /// Returns the RLP-encoding.
@@ -299,9 +302,9 @@ fn test_delete_with_unresolved_sibling_errors() {
     let digest_id = trie.add_node(NodeData::Digest(fake_digest), None);
 
     // Create a branch with these two children
-    let mut children: [Option<u32>; 16] = Default::default();
-    children[0] = Some(leaf_id);
-    children[1] = Some(digest_id);
+    let mut children: [Option<BranchChildId>; 16] = Default::default();
+    children[0] = BranchChildId::new(leaf_id);
+    children[1] = BranchChildId::new(digest_id);
     let branch_children = trie.alloc_branch(children);
     let branch_node_id = trie.add_node(NodeData::Branch(branch_children), None);
 

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -17,7 +17,7 @@ use crate::{
         encoded_path_eq_key, encoded_path_from_key, encoded_path_strip_prefix_key, lcp_key,
         prefix_to_nibs, to_encoded_path_with_bump, KeyNibbles,
     },
-    node::{BranchChildren, NodeData, NodeId, NodeRef},
+    node::{BranchChildId, BranchChildren, NodeData, NodeId, NodeRef},
 };
 
 /// OpenVM memory alignment word size.
@@ -153,6 +153,14 @@ fn put_digest<B: alloy_rlp::BufMut>(digest: &[u8], out: &mut B) {
     }
 }
 
+/// Converts a node id to a branch child slot id.
+/// The only zero id is the null-node sentinel ([`NULL_NODE_ID`]), which is never stored as a
+/// branch child.
+#[inline(always)]
+fn branch_child_id(node_id: NodeId) -> BranchChildId {
+    BranchChildId::new(node_id).expect("the null-node sentinel is never a branch child")
+}
+
 /// Writes an RLP header with the given base code (`EMPTY_LIST_CODE` for lists,
 /// `EMPTY_STRING_CODE` for strings). Emits the same bytes as [`alloy_rlp::Header::encode`], but
 /// is generic over the output buffer: `alloy_rlp` encoding goes through `&mut dyn BufMut`, and
@@ -210,7 +218,7 @@ impl<'a> Mpt<'a> {
         match self.nodes[node_id as usize] {
             NodeData::Branch(children) => {
                 for child_id in children.iter().filter_map(Cell::get) {
-                    self.encode_trie_internal(child_id, out);
+                    self.encode_trie_internal(child_id.get(), out);
                 }
             }
             NodeData::Extension(_, ext_id) => {
@@ -364,7 +372,7 @@ impl<'a> Mpt<'a> {
             if is_null_ref(child0_expected_node_ref.as_slice()) {
                 None
             } else {
-                Some(self.decode_trie_internal(bytes, child0_expected_node_ref)?)
+                Some(branch_child_id(self.decode_trie_internal(bytes, child0_expected_node_ref)?))
             }
         };
 
@@ -373,7 +381,7 @@ impl<'a> Mpt<'a> {
             if is_null_ref(child1_expected_node_ref.as_slice()) {
                 None
             } else {
-                Some(self.decode_trie_internal(bytes, child1_expected_node_ref)?)
+                Some(branch_child_id(self.decode_trie_internal(bytes, child1_expected_node_ref)?))
             }
         };
 
@@ -385,8 +393,8 @@ impl<'a> Mpt<'a> {
         let childs = unsafe {
             &mut *self
                 .bump
-                .alloc_layout(Layout::new::<[Cell<Option<NodeId>>; 16]>())
-                .cast::<[MaybeUninit<Option<NodeId>>; 16]>()
+                .alloc_layout(Layout::new::<[Cell<Option<BranchChildId>>; 16]>())
+                .cast::<[MaybeUninit<Option<BranchChildId>>; 16]>()
                 .as_ptr()
         };
 
@@ -410,7 +418,9 @@ impl<'a> Mpt<'a> {
                 if is_null_ref(child_expected_node_ref.as_slice()) {
                     None
                 } else {
-                    Some(self.decode_trie_internal(bytes, child_expected_node_ref)?)
+                    Some(branch_child_id(
+                        self.decode_trie_internal(bytes, child_expected_node_ref)?,
+                    ))
                 }
             });
         }
@@ -423,8 +433,8 @@ impl<'a> Mpt<'a> {
         // SAFETY: all elements of the array were initialized above, and `Cell<T>` is
         // `repr(transparent)` over `T`.
         let children: BranchChildren<'a> = unsafe {
-            &*(childs as *const [MaybeUninit<Option<NodeId>>; 16]
-                as *const [Cell<Option<NodeId>>; 16])
+            &*(childs as *const [MaybeUninit<Option<BranchChildId>>; 16]
+                as *const [Cell<Option<BranchChildId>>; 16])
         };
         let node_id = self.add_node(NodeData::Branch(children), Some(node_ref));
         Ok(node_id)
@@ -483,7 +493,7 @@ impl<'a> Mpt<'a> {
                 encode_header(alloy_rlp::EMPTY_LIST_CODE, payload_length, out);
                 for child_id in children.iter() {
                     match child_id.get() {
-                        Some(id) => self.reference_encode(id, out),
+                        Some(id) => self.reference_encode(id.get(), out),
                         None => out.put_u8(alloy_rlp::EMPTY_STRING_CODE),
                     }
                 }
@@ -536,7 +546,7 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 1 + children
                     .iter()
-                    .map(|child| child.get().map_or(1, |id| self.reference_length(id)))
+                    .map(|child| child.get().map_or(1, |id| self.reference_length(id.get())))
                     .sum::<usize>()
             }
             NodeData::Leaf(encoded_path, value) => encoded_path.length() + value.length(),
@@ -662,7 +672,7 @@ impl<'a> Mpt<'a> {
     /// Allocates a branch children array in the bump arena, to be stored in a
     /// [`NodeData::Branch`].
     #[inline]
-    pub(crate) fn alloc_branch(&self, children: [Option<NodeId>; 16]) -> BranchChildren<'a> {
+    pub(crate) fn alloc_branch(&self, children: [Option<BranchChildId>; 16]) -> BranchChildren<'a> {
         self.bump.alloc(children.map(Cell::new))
     }
 
@@ -711,7 +721,7 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
-                        Some(id) => self.get_internal(id, tail),
+                        Some(id) => self.get_internal(id.get(), tail),
                         None => Ok(None),
                     }
                 } else {
@@ -754,11 +764,11 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
-                        Some(id) => self.insert_internal(id, tail, value)?,
+                        Some(id) => self.insert_internal(id.get(), tail, value)?,
                         None => {
                             let path = encoded_path_from_key(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            children[usize::from(i)].set(Some(new_leaf_id));
+                            children[usize::from(i)].set(Some(branch_child_id(new_leaf_id)));
                             true
                         }
                     }
@@ -783,7 +793,7 @@ impl<'a> Mpt<'a> {
                     } else {
                         // otherwise, create a branch with two children
                         let split_point = common_len + 1;
-                        let mut children: [Option<NodeId>; 16] = Default::default();
+                        let mut children: [Option<BranchChildId>; 16] = Default::default();
 
                         let leaf1_path =
                             to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], true);
@@ -793,8 +803,9 @@ impl<'a> Mpt<'a> {
                             encoded_path_from_key(self.bump, key.advanced(split_point), true);
                         let leaf2_id = self.add_node(NodeData::Leaf(leaf2_path, value), None);
 
-                        children[self_nibs[common_len] as usize] = Some(leaf1_id);
-                        children[usize::from(key.nib(common_len))] = Some(leaf2_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(leaf1_id));
+                        children[usize::from(key.nib(common_len))] =
+                            Some(branch_child_id(leaf2_id));
 
                         let branch_children = self.alloc_branch(children);
                         let new_node_data = if common_len > 0 {
@@ -825,21 +836,21 @@ impl<'a> Mpt<'a> {
                         return Err(Error::ValueInBranch);
                     }
                     let split_point = common_len + 1;
-                    let mut children: [Option<NodeId>; 16] = Default::default();
+                    let mut children: [Option<BranchChildId>; 16] = Default::default();
 
                     if split_point < self_nibs.len() {
                         let ext_path =
                             to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], false);
                         let ext_id = self.add_node(NodeData::Extension(ext_path, child_id), None);
-                        children[self_nibs[common_len] as usize] = Some(ext_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(ext_id));
                     } else {
-                        children[self_nibs[common_len] as usize] = Some(child_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(child_id));
                     }
 
                     let leaf_path =
                         encoded_path_from_key(self.bump, key.advanced(split_point), true);
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
-                    children[usize::from(key.nib(common_len))] = Some(leaf_id);
+                    children[usize::from(key.nib(common_len))] = Some(branch_child_id(leaf_id));
 
                     let branch_children = self.alloc_branch(children);
                     let new_node_data = if common_len > 0 {
@@ -874,6 +885,7 @@ impl<'a> Mpt<'a> {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
                         Some(id) => {
+                            let id = id.get();
                             if !self.delete_internal(id, tail)? {
                                 return Ok(false);
                             }
@@ -892,7 +904,7 @@ impl<'a> Mpt<'a> {
                 let mut remaining_iter = children
                     .iter()
                     .enumerate()
-                    .filter_map(|(index, n)| n.get().map(|id| (index, id)));
+                    .filter_map(|(index, n)| n.get().map(|id| (index, id.get())));
 
                 // there will always be at least one remaining node
                 let (index, child_id) = remaining_iter.next().unwrap();
@@ -1040,10 +1052,11 @@ impl<'a> Mpt<'a> {
                         return Err(Error::ValueInBranch);
                     }
 
-                    let mut childs: [Option<NodeId>; 16] = Default::default();
+                    let mut childs: [Option<BranchChildId>; 16] = Default::default();
                     for (i, mut item) in items.into_iter().take(16).enumerate() {
                         let child_id = self.decode_from_proof_rlp_internal(&mut item)?;
-                        childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
+                        // `BranchChildId::new` maps the `NULL_NODE_ID` sentinel (0) to `None`.
+                        childs[i] = BranchChildId::new(child_id);
                     }
                     let children = self.alloc_branch(childs);
                     self.add_node(NodeData::Branch(children), None)
@@ -1076,7 +1089,7 @@ impl<'a> Mpt<'a> {
         match &self.nodes[node_id as usize] {
             NodeData::Branch(children) => {
                 for child_id in children.iter().filter_map(Cell::get) {
-                    self.payloads_internal(child_id, payloads);
+                    self.payloads_internal(child_id.get(), payloads);
                 }
             }
             NodeData::Extension(_, ext_id) => {
@@ -1105,7 +1118,7 @@ impl Mpt<'_> {
                 for (i, child) in children.iter().enumerate() {
                     if let Some(child_id) = child.get() {
                         println!("{}  [{}]:", indent, hex::encode([i as u8]));
-                        self.print_trie_internal(child_id, depth + 2);
+                        self.print_trie_internal(child_id.get(), depth + 2);
                     }
                 }
             }


### PR DESCRIPTION
Stacked on #647.

Branch children were `Cell<Option<u32>>`. Since `Option<u32>` is 8 bytes, every 16-slot array was 128 bytes. Node ID 0 is already the null sentinel and never a valid child, so this uses `Option<NonZeroU32>`: 4-byte slots and 64-byte arrays.

This removes the separate option discriminant, reducing array initialization and child-access memory operations. The decoder and resolver map 0 directly to `None`.

## Benchmark results

Block 24001988, execute-metered, marginal against its own parent — [#647](https://github.com/axiom-crypto/openvm-eth/actions/runs/30340549147) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30340550900):

| metric | #647 | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 574,453,920 | 573,518,844 | −935,076 (−0.163%) |
| `metered_rows_unpadded` | 824,046,497 | 821,986,167 | −2,060,330 (−0.250%) |
| `metered_main_cells_unpadded` | 42,872,670,780 | 42,655,380,312 | **−217,290,468 (−0.507%)** |
| `metered_interaction_cells_unpadded` | 12,950,922,566 | 12,920,344,836 | −30,577,730 (−0.236%) |
| `metered_memory_unpadded_bytes` | 708,107,444,291 | 705,340,794,254 | −2,766,650,037 (−0.391%) |
| app segments | 63 | 63 | 0 |

The smaller slots are a memory-layout win rather than an instruction win: main cells fall 0.507% for a 0.163% instruction reduction. No segment boundary is crossed on this block.

Cumulative with #647, against [`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031): `execute_metered_insns` 588,618,511 → 573,518,844 (**−2.565%**), main cells −1.399%, app segments 65 → 63.
