### PR TITLE
perf(mpt): specialize common RLP headers

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -113,12 +113,46 @@ fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error
         *buf = &item_start[1..];
         return Ok((&item_start[..1], &item_start[1..1]));
     }
+    if item_start.first() == Some(&(alloy_rlp::EMPTY_STRING_CODE + 32)) {
+        let item = item_start.get(..33).ok_or(alloy_rlp::Error::InputTooShort)?;
+        *buf = &item_start[33..];
+        return Ok((item, &item[1..]));
+    }
 
     let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
     // SAFETY: the header was decoded, so the item contains its declared payload.
     let payload = unsafe { advance_unchecked(buf, payload_length) };
     let item_length = item_start.len() - buf.len();
     Ok((&item_start[..item_length], payload))
+}
+
+/// Decodes an MPT node header, specializing the canonical list headers used by almost every
+/// resolved node. The generic decoder remains the fallback for strings and uncommon long lists.
+#[inline(always)]
+fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
+    let input = *buf;
+    match input.first().copied() {
+        Some(code @ alloy_rlp::EMPTY_LIST_CODE..=0xf7) => {
+            let payload_length = usize::from(code - alloy_rlp::EMPTY_LIST_CODE);
+            if input.len() < payload_length + 1 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[1..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf8) => {
+            let payload_length = usize::from(*input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?);
+            if payload_length < 56 {
+                return Err(alloy_rlp::Error::NonCanonicalSize.into());
+            }
+            if input.len() < payload_length + 2 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[2..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        _ => alloy_rlp::Header::decode(buf).map_err(Into::into),
+    }
 }
 
 /// Whether `slice` is the RLP encoding of an empty node reference: a single `EMPTY_STRING_CODE`
@@ -287,7 +321,7 @@ impl<'a> Mpt<'a> {
         }
 
         let rlp_node_header_start = *bytes;
-        let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(bytes)?;
+        let alloy_rlp::Header { list, payload_length } = decode_node_header(bytes)?;
 
         // SAFETY: we already decoded the header, so we know the payload length.
         let mut payload = unsafe { advance_unchecked(bytes, payload_length) };


### PR DESCRIPTION
Stacked on #665.

Specialize the canonical RLP headers used by nearly every resolved MPT node: short list headers, one-byte long-list headers, and fixed 32-byte child references. Uncommon and malformed forms retain the generic `alloy_rlp` decoder as a checked fallback.

## Benchmark results

Block 24001988, `prove-stark`, RVR, g7e.2xlarge: [before](https://github.com/axiom-crypto/openvm-eth/actions/runs/29750974205), [with specialized headers](https://github.com/axiom-crypto/openvm-eth/actions/runs/29765316772).

| metric | before | with this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 640,063,687 | 635,122,863 | **−4,940,824 (−0.77%)** |
| `metered_rows_unpadded` | 923,404,883 | 918,512,602 | −4,892,281 (−0.53%) |
| `metered_main_cells_unpadded` | 46,872,486,323 | 46,712,135,069 | −160,351,254 (−0.34%) |
| `metered_interaction_cells_unpadded` | 14,381,062,111 | 14,298,657,640 | −82,404,471 (−0.57%) |
| `total_cells` | 63,193,141,279 | 62,961,656,223 | **−231,485,056 (−0.37%)** |

### Block 24003902

RVR execution: [#665](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838155247), [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838157862).

| metric | #665 | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 511,200,060 | 510,039,370 | **−1,160,690 (−0.23%)** |
| `metered_rows_unpadded` | 691,954,121 | 690,800,979 | −1,153,142 (−0.17%) |
| `metered_main_cells_unpadded` | 30,054,639,856 | 30,015,457,221 | −39,182,635 (−0.13%) |
| `metered_interaction_cells_unpadded` | 11,974,365,720 | 11,954,965,713 | −19,400,007 (−0.16%) |
| `metered_memory_unpadded_bytes` | 574,055,559,407 | 573,582,845,194 | −472,714,213 (−0.08%) |
| memory-triggered segment cuts | 51 | 51 | 0 |