### PR TITLE
perf(mpt): specialize remaining common RLP headers

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -103,9 +103,8 @@ unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
     bytes
 }
 
-/// Decodes and advances past one RLP item, returning its full encoding and payload.
-/// Empty strings dominate sparse branch children, so handle their single-byte encoding without
-/// entering the generic RLP header decoder.
+/// Decodes and advances past one RLP item, returning its full encoding and payload. Common
+/// single-byte headers are handled directly, with the generic decoder as a fallback.
 #[inline(always)]
 fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error> {
     let item_start = *buf;
@@ -118,6 +117,16 @@ fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error
         *buf = &item_start[33..];
         return Ok((item, &item[1..]));
     }
+    if let Some(code @ 0x81..=0xb7) = item_start.first().copied() {
+        let payload_length = usize::from(code - alloy_rlp::EMPTY_STRING_CODE);
+        let item = item_start.get(..payload_length + 1).ok_or(alloy_rlp::Error::InputTooShort)?;
+        let payload = &item[1..];
+        if payload_length == 1 && payload[0] < alloy_rlp::EMPTY_STRING_CODE {
+            return Err(alloy_rlp::Error::NonCanonicalSingleByte.into());
+        }
+        *buf = &item_start[payload_length + 1..];
+        return Ok((item, payload));
+    }
 
     let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
     // SAFETY: the header was decoded, so the item contains its declared payload.
@@ -126,8 +135,8 @@ fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error
     Ok((&item_start[..item_length], payload))
 }
 
-/// Decodes an MPT node header, specializing the canonical list headers used by almost every
-/// resolved node. The generic decoder remains the fallback for strings and uncommon long lists.
+/// Decodes an MPT node header, specializing the canonical list headers used by resolved nodes.
+/// The generic decoder remains the fallback for strings and larger lists.
 #[inline(always)]
 fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
     let input = *buf;
@@ -149,6 +158,19 @@ fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
                 return Err(alloy_rlp::Error::InputTooShort.into());
             }
             *buf = &input[2..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf9) => {
+            let high = *input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?;
+            let low = *input.get(2).ok_or(alloy_rlp::Error::InputTooShort)?;
+            if high == 0 {
+                return Err(alloy_rlp::Error::LeadingZero.into());
+            }
+            let payload_length = (usize::from(high) << 8) | usize::from(low);
+            if input.len() < payload_length + 3 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[3..];
             Ok(alloy_rlp::Header { list: true, payload_length })
         }
         _ => alloy_rlp::Header::decode(buf).map_err(Into::into),


### PR DESCRIPTION
Stacked on #666.

Handle canonical short-string headers and two-byte long-list lengths directly during MPT witness decoding. The dominant `0x80` and `0xa0` paths remain first and unchanged, while uncommon forms retain the generic fallback.

## Benchmark results

Block 24001988, RVR execution: [#666](https://github.com/axiom-crypto/openvm-eth/actions/runs/29822417843), [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/29822527281).

| metric | #666 | this PR | delta |
| --- | ---: | ---: | ---: |
| instructions | 635,001,371 | 632,797,192 | −2,204,179 (−0.35%) |
| rows (unpadded) | 918,403,605 | 916,168,884 | −2,234,721 (−0.24%) |
| main cells (unpadded) | 46,698,352,107 | 46,640,829,085 | −57,523,022 (−0.12%) |
| interaction cells (unpadded) | 14,296,765,843 | 14,264,136,920 | −32,628,923 (−0.23%) |

### Block 24003902

RVR execution: [#666](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838157862), [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838160305).

| metric | #666 | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 510,039,370 | 509,497,798 | **−541,572 (−0.11%)** |
| `metered_rows_unpadded` | 690,800,979 | 690,257,462 | −543,517 (−0.08%) |
| `metered_main_cells_unpadded` | 30,015,457,221 | 29,999,653,205 | −15,804,016 (−0.05%) |
| `metered_interaction_cells_unpadded` | 11,954,965,713 | 11,947,014,482 | −7,951,231 (−0.07%) |
| `metered_memory_unpadded_bytes` | 573,582,845,194 | 573,403,752,933 | −179,092,261 (−0.03%) |
| memory-triggered segment cuts | 51 | 51 | 0 |