### PR TITLE
perf: hash through an aligned keccak sponge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7334,6 +7334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-guest-keccak"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "openvm-keccak256-guest",
+ "openvm-platform",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "openvm-instructions"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0#530eb47efa03690c44c0529e9cc598e77ed0fb67"
@@ -7485,6 +7495,7 @@ dependencies = [
  "alloy-trie 0.9.4",
  "bumpalo",
  "bytes",
+ "openvm-guest-keccak",
  "revm 40.0.3",
  "revm-primitives 24.0.1",
  "serde",
@@ -8082,6 +8093,7 @@ dependencies = [
  "bumpalo",
  "itertools 0.14.0",
  "openvm-chainspec",
+ "openvm-guest-keccak",
  "openvm-mpt",
  "openvm-revm-crypto",
  "reth-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mpt",
     "crates/revm-crypto",
     "crates/stateless-executor",
+    "crates/guest-keccak",
     "crates/chainspec",
     "crates/stateless-witness",
     "crates/mpt-tools",
@@ -47,6 +48,7 @@ toml = "0.9.2"
 smallvec = "1.13"
 bumpalo = { version = "3.19.0", default-features = false, features = ["collections"] }
 bytes = { version = "1", default-features = false }
+tiny-keccak = { version = "2.0", features = ["keccak"] }
 itertools = { version = "0.14", default-features = false }
 actix-web = "4"
 reqwest = "0.12.20"
@@ -61,6 +63,7 @@ openvm-curve-utils = { path = "./crates/curve-utils", default-features = false }
 openvm-kzg = { path = "./crates/kzg", default-features = false }
 openvm-mpt = { path = "./crates/mpt" }
 openvm-revm-crypto = { path = "./crates/revm-crypto" }
+openvm-guest-keccak = { path = "./crates/guest-keccak" }
 openvm-stateless-executor = { path = "./crates/stateless-executor" }
 openvm-chainspec = { path = "./crates/chainspec" }
 # workspace (host only)
@@ -111,6 +114,8 @@ openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "d
 openvm-verify-stark-host = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false }
 openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false }
 openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false }
+openvm-keccak256-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false }
 openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false, features = [
     "bn254",
     "bls12_381",

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2560,6 +2560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-guest-keccak"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "openvm-keccak256-guest",
+ "openvm-platform",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "openvm-keccak256"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0#530eb47efa03690c44c0529e9cc598e77ed0fb67"
@@ -2614,6 +2624,7 @@ dependencies = [
  "alloy-trie",
  "bumpalo",
  "bytes",
+ "openvm-guest-keccak",
  "revm",
  "revm-primitives",
  "serde",
@@ -2731,6 +2742,7 @@ dependencies = [
  "bumpalo",
  "itertools 0.14.0",
  "openvm-chainspec",
+ "openvm-guest-keccak",
  "openvm-mpt",
  "openvm-revm-crypto",
  "reth-consensus",

--- a/crates/guest-keccak/Cargo.toml
+++ b/crates/guest-keccak/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "openvm-guest-keccak"
+description = "Keccak-256 sponge tuned for the OpenVM guest target"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+bytes.workspace = true
+openvm-keccak256-guest.workspace = true
+openvm-platform.workspace = true
+
+[target.'cfg(not(target_os = "openvm"))'.dependencies]
+tiny-keccak.workspace = true

--- a/crates/guest-keccak/src/lib.rs
+++ b/crates/guest-keccak/src/lib.rs
@@ -233,21 +233,39 @@ pub fn keccak256(bytes: &[u8]) -> [u8; OUTPUT_SIZE] {
     sponge.finalize()
 }
 
-/// XORs `len` bytes at `input` into the front of the sponge state with a single XORIN
-/// instruction, emitted directly: the sponge upholds the instruction's alignment
-/// requirements by construction, so `native_xorin`'s per-call checks and staging
-/// fallback are unnecessary.
+/// XORs `len` bytes at `input` into the front of the sponge state.
+///
+/// The preconditions are asserted here rather than inside the target-specific bodies below,
+/// so that host runs check the same contract the XORIN instruction depends on. The byte-wise
+/// stand-in tolerates any length and alignment, so an assertion placed only in the guest body
+/// would be unreachable in tests — exactly where a violated precondition is cheapest to catch.
 ///
 /// # Safety
 ///
 /// `input` must be valid for `len` initialized bytes, 8-byte aligned, with `len` a
 /// multiple of 8 and at most `RATE`.
-#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
 #[inline(always)]
 unsafe fn xorin(state: &mut State, input: *const u8, len: usize) {
+    debug_assert!(
+        len <= RATE && len % GUEST_ALIGN == 0,
+        "XORIN length must be an 8-byte multiple within the rate, got {len}"
+    );
+    debug_assert_eq!(input.addr() % GUEST_ALIGN, 0, "XORIN input must be 8-byte aligned");
+    // SAFETY: forwarded unchanged from this function's own contract.
+    unsafe { xorin_impl(state, input, len) }
+}
+
+/// Emits the XORIN instruction directly: the sponge upholds the instruction's alignment
+/// requirements by construction, so `native_xorin`'s per-call checks and staging fallback are
+/// unnecessary.
+///
+/// # Safety
+///
+/// As [`xorin`].
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
+#[inline(always)]
+unsafe fn xorin_impl(state: &mut State, input: *const u8, len: usize) {
     use openvm_keccak256_guest::{OPCODE, XORIN_FUNCT3, XORIN_FUNCT7};
-    debug_assert!(len <= RATE && len % GUEST_ALIGN == 0);
-    debug_assert_eq!(input.addr() % GUEST_ALIGN, 0);
     let mut state_ptr = state.0.as_mut_ptr();
     openvm_platform::custom_insn_r!(
         opcode = OPCODE,
@@ -259,8 +277,13 @@ unsafe fn xorin(state: &mut State, input: *const u8, len: usize) {
     );
 }
 
+/// Byte-wise stand-in for the XORIN instruction on non-guest targets.
+///
+/// # Safety
+///
+/// As [`xorin`].
 #[cfg(not(any(openvm_intrinsics, target_os = "openvm")))]
-unsafe fn xorin(state: &mut State, input: *const u8, len: usize) {
+unsafe fn xorin_impl(state: &mut State, input: *const u8, len: usize) {
     // SAFETY: the caller passes `input` valid for `len` initialized bytes.
     let input = unsafe { core::slice::from_raw_parts(input, len) };
     for (state_byte, input_byte) in state.0.iter_mut().zip(input) {

--- a/crates/guest-keccak/src/lib.rs
+++ b/crates/guest-keccak/src/lib.rs
@@ -1,0 +1,297 @@
+//! Keccak-256 sponge tuned for the OpenVM guest.
+//!
+//! The guest's default keccak path (`alloy-primitives`' `native-keccak` hook) locks a
+//! static hasher and absorbs input through openvm's `native_xorin` wrapper, which
+//! allocates aligned staging buffers and copies both the input and the Keccak state
+//! whenever a pointer or a length is not 8-byte aligned. RLP-encoded trie nodes,
+//! addresses, and storage keys hit those paths constantly, and the staging allocations
+//! are never reclaimed by the guest's bump allocator.
+//!
+//! [`Keccak256Sponge`] keeps an 8-byte-aligned state and rate buffer of its own and
+//! only issues XORIN instructions with 8-byte-aligned pointers and lengths, emitted
+//! directly without the wrapper's checks. The final partial block is zero-padded to an
+//! 8-byte multiple before being absorbed — XOR-ing zero bytes into the state is a
+//! no-op — and the sponge padding is applied directly to the state.
+//!
+//! The [`bytes::BufMut`] implementation lets callers stream serialized data (e.g. RLP
+//! encoding) straight into the hash without materializing it in a scratch buffer.
+
+#![no_std]
+
+use core::mem::MaybeUninit;
+
+use bytes::{buf::UninitSlice, BufMut};
+
+/// Keccak-256 sponge rate in bytes.
+const RATE: usize = openvm_keccak256_guest::KECCAK_RATE;
+/// Keccak-f\[1600\] state width in bytes.
+const STATE_BYTES: usize = openvm_keccak256_guest::KECCAK_WIDTH_BYTES;
+/// Keccak-256 digest size in bytes.
+pub const OUTPUT_SIZE: usize = openvm_keccak256_guest::KECCAK_OUTPUT_SIZE;
+/// Alignment maintained for buffers passed directly to the OpenVM instructions.
+const GUEST_ALIGN: usize = 8;
+
+const _: () = assert!(GUEST_ALIGN % openvm_keccak256_guest::MIN_ALIGN == 0);
+
+/// The Keccak state, aligned so the native XORIN/KECCAKF instructions accept it
+/// without staging copies.
+#[derive(Debug)]
+#[repr(align(8))]
+struct State([u8; STATE_BYTES]);
+
+/// Staging buffer for one rate block, aligned for the native XORIN fast path. Left
+/// uninitialized on construction: only the `fill`-byte prefix tracked by the sponge is
+/// ever initialized, and only initialized bytes are read.
+#[derive(Debug)]
+#[repr(align(8))]
+struct Block(MaybeUninit<[u8; RATE]>);
+
+/// An incremental Keccak-256 hasher.
+#[derive(Debug)]
+pub struct Keccak256Sponge {
+    state: State,
+    block: Block,
+    /// Initialized prefix of `block` (`0..=RATE`; `RATE` means a full block that is
+    /// absorbed lazily by the next operation).
+    fill: usize,
+    /// Number of rate blocks absorbed so far, tracked for [`Self::absorbed_len`].
+    blocks: usize,
+}
+
+impl Keccak256Sponge {
+    /// Creates an empty sponge.
+    pub const fn new() -> Self {
+        Self {
+            state: State([0; STATE_BYTES]),
+            block: Block(MaybeUninit::uninit()),
+            fill: 0,
+            blocks: 0,
+        }
+    }
+
+    /// Total number of bytes absorbed so far.
+    #[inline]
+    pub fn absorbed_len(&self) -> usize {
+        self.blocks * RATE + self.fill
+    }
+
+    #[inline(always)]
+    fn block_ptr(&mut self) -> *mut u8 {
+        self.block.0.as_mut_ptr().cast::<u8>()
+    }
+
+    /// Copies `bytes` into the staged block. The caller keeps the result within the
+    /// block: `fill + bytes.len() <= RATE`.
+    #[inline(always)]
+    fn stage(&mut self, bytes: &[u8]) {
+        debug_assert!(self.fill + bytes.len() <= RATE);
+        // SAFETY: the destination range lies within the RATE-byte block, and staging
+        // extends the initialized prefix contiguously.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                self.block_ptr().add(self.fill),
+                bytes.len(),
+            );
+        }
+        self.fill += bytes.len();
+    }
+
+    #[inline(always)]
+    fn flush_if_full(&mut self) {
+        if self.fill == RATE {
+            let block = self.block_ptr();
+            // SAFETY: all RATE staged bytes are initialized and the block is 8-byte
+            // aligned.
+            unsafe { xorin(&mut self.state, block, RATE) };
+            keccakf(&mut self.state);
+            self.blocks += 1;
+            self.fill = 0;
+        }
+    }
+
+    /// Absorbs `bytes` into the sponge.
+    #[inline]
+    pub fn absorb(&mut self, bytes: &[u8]) {
+        if self.fill + bytes.len() <= RATE {
+            self.stage(bytes);
+        } else {
+            self.absorb_overflowing(bytes);
+        }
+    }
+
+    /// Absorb path for inputs that do not fit in the staged block.
+    fn absorb_overflowing(&mut self, mut bytes: &[u8]) {
+        self.flush_if_full();
+        if self.fill != 0 {
+            let take = usize::min(RATE - self.fill, bytes.len());
+            self.stage(&bytes[..take]);
+            bytes = &bytes[take..];
+            if bytes.is_empty() {
+                return;
+            }
+            self.flush_if_full();
+        }
+        while bytes.len() >= RATE {
+            let (head, rest) = bytes.split_at(RATE);
+            if head.as_ptr().addr() % GUEST_ALIGN == 0 {
+                // Absorb aligned blocks straight from the input.
+                // SAFETY: `head` is RATE initialized bytes and 8-byte aligned.
+                unsafe { xorin(&mut self.state, head.as_ptr(), RATE) };
+                keccakf(&mut self.state);
+                self.blocks += 1;
+            } else {
+                self.stage(head);
+                self.flush_if_full();
+            }
+            bytes = rest;
+        }
+        self.stage(bytes);
+    }
+
+    /// Applies the Keccak-256 padding and returns the digest.
+    ///
+    /// The sponge must not be used for further hashing afterwards: absorbing more data
+    /// would continue from the squeezed state, not from a fresh one.
+    #[inline]
+    pub fn finalize(&mut self) -> [u8; OUTPUT_SIZE] {
+        self.flush_if_full();
+        if self.fill != 0 {
+            // Absorb the staged tail zero-padded to an 8-byte multiple; the extra zero
+            // bytes leave the state untouched.
+            let end = self.fill.next_multiple_of(GUEST_ALIGN);
+            // SAFETY: the padded range lies within the RATE-byte block and extends the
+            // initialized prefix, so the xorin below reads only initialized bytes.
+            unsafe {
+                core::ptr::write_bytes(self.block_ptr().add(self.fill), 0, end - self.fill);
+                let block = self.block_ptr();
+                xorin(&mut self.state, block, end);
+            }
+        }
+        // pad10*1, applied directly to the state.
+        self.state.0[self.fill] ^= 0x01;
+        self.state.0[RATE - 1] ^= 0x80;
+        keccakf(&mut self.state);
+        let mut digest = [0; OUTPUT_SIZE];
+        digest.copy_from_slice(&self.state.0[..OUTPUT_SIZE]);
+        digest
+    }
+}
+
+impl Default for Keccak256Sponge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Streams written bytes into the hash. Writers stage data in the sponge's aligned rate
+/// buffer, so hashing serialized data needs no intermediate scratch buffer.
+unsafe impl BufMut for Keccak256Sponge {
+    #[inline(always)]
+    fn remaining_mut(&self) -> usize {
+        usize::MAX
+    }
+
+    #[inline(always)]
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        let fill = self.fill + cnt;
+        assert!(fill <= RATE, "advanced {cnt} bytes past the staged keccak block");
+        self.fill = fill;
+    }
+
+    #[inline(always)]
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
+        self.flush_if_full();
+        let fill = self.fill;
+        let chunk = self.block_ptr();
+        // SAFETY: the returned slice covers exactly the unfilled suffix of the block;
+        // `advance_mut` extends the initialized prefix only after the caller wrote it.
+        unsafe { UninitSlice::from_raw_parts_mut(chunk.add(fill), RATE - fill) }
+    }
+
+    #[inline]
+    fn put_slice(&mut self, src: &[u8]) {
+        self.absorb(src);
+    }
+
+    #[inline]
+    fn put_u8(&mut self, n: u8) {
+        self.flush_if_full();
+        let fill = self.fill;
+        // SAFETY: `fill < RATE` after the flush above, and the write extends the
+        // initialized prefix by one byte.
+        unsafe { self.block_ptr().add(fill).write(n) };
+        self.fill = fill + 1;
+    }
+}
+
+/// Computes the Keccak-256 digest of `bytes`.
+#[inline]
+pub fn keccak256(bytes: &[u8]) -> [u8; OUTPUT_SIZE] {
+    let mut sponge = Keccak256Sponge::new();
+    sponge.absorb(bytes);
+    sponge.finalize()
+}
+
+/// XORs `len` bytes at `input` into the front of the sponge state with a single XORIN
+/// instruction, emitted directly: the sponge upholds the instruction's alignment
+/// requirements by construction, so `native_xorin`'s per-call checks and staging
+/// fallback are unnecessary.
+///
+/// # Safety
+///
+/// `input` must be valid for `len` initialized bytes, 8-byte aligned, with `len` a
+/// multiple of 8 and at most `RATE`.
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
+#[inline(always)]
+unsafe fn xorin(state: &mut State, input: *const u8, len: usize) {
+    use openvm_keccak256_guest::{OPCODE, XORIN_FUNCT3, XORIN_FUNCT7};
+    debug_assert!(len <= RATE && len % GUEST_ALIGN == 0);
+    debug_assert_eq!(input.addr() % GUEST_ALIGN, 0);
+    let mut state_ptr = state.0.as_mut_ptr();
+    openvm_platform::custom_insn_r!(
+        opcode = OPCODE,
+        funct3 = XORIN_FUNCT3,
+        funct7 = XORIN_FUNCT7,
+        rd = InOut state_ptr,
+        rs1 = In input,
+        rs2 = In len
+    );
+}
+
+#[cfg(not(any(openvm_intrinsics, target_os = "openvm")))]
+unsafe fn xorin(state: &mut State, input: *const u8, len: usize) {
+    // SAFETY: the caller passes `input` valid for `len` initialized bytes.
+    let input = unsafe { core::slice::from_raw_parts(input, len) };
+    for (state_byte, input_byte) in state.0.iter_mut().zip(input) {
+        *state_byte ^= *input_byte;
+    }
+}
+
+/// Applies the Keccak-f\[1600\] permutation to the state.
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
+#[inline(always)]
+fn keccakf(state: &mut State) {
+    use openvm_keccak256_guest::{KECCAKF_FUNCT3, KECCAKF_FUNCT7, OPCODE};
+    let mut state_ptr = state.0.as_mut_ptr();
+    openvm_platform::custom_insn_r!(
+        opcode = OPCODE,
+        funct3 = KECCAKF_FUNCT3,
+        funct7 = KECCAKF_FUNCT7,
+        rd = InOut state_ptr,
+        rs1 = Const "x0",
+        rs2 = Const "x0",
+    );
+}
+
+#[cfg(not(any(openvm_intrinsics, target_os = "openvm")))]
+fn keccakf(state: &mut State) {
+    let mut lanes = [0u64; 25];
+    for (lane, bytes) in lanes.iter_mut().zip(state.0.chunks_exact(8)) {
+        *lane = u64::from_le_bytes(bytes.try_into().expect("chunks are 8 bytes"));
+    }
+    tiny_keccak::keccakf(&mut lanes);
+    for (lane, bytes) in lanes.iter().zip(state.0.chunks_exact_mut(8)) {
+        bytes.copy_from_slice(&lane.to_le_bytes());
+    }
+}

--- a/crates/guest-keccak/src/lib.rs
+++ b/crates/guest-keccak/src/lib.rs
@@ -218,6 +218,7 @@ unsafe impl BufMut for Keccak256Sponge {
     fn put_u8(&mut self, n: u8) {
         self.flush_if_full();
         let fill = self.fill;
+        debug_assert!(fill < RATE, "the flush above must leave room for one byte");
         // SAFETY: `fill < RATE` after the flush above, and the write extends the
         // initialized prefix by one byte.
         unsafe { self.block_ptr().add(fill).write(n) };

--- a/crates/guest-keccak/tests/differential.rs
+++ b/crates/guest-keccak/tests/differential.rs
@@ -1,0 +1,119 @@
+use bytes::BufMut;
+use openvm_guest_keccak::{keccak256, Keccak256Sponge, OUTPUT_SIZE};
+use tiny_keccak::Hasher;
+
+fn reference(bytes: &[u8]) -> [u8; OUTPUT_SIZE] {
+    let mut hasher = tiny_keccak::Keccak::v256();
+    hasher.update(bytes);
+    let mut digest = [0; OUTPUT_SIZE];
+    hasher.finalize(&mut digest);
+    digest
+}
+
+/// Deterministic pseudo-random bytes (xorshift), independent of test order.
+fn test_bytes(len: usize, mut seed: u64) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        bytes.extend_from_slice(&seed.to_le_bytes());
+    }
+    bytes.truncate(len);
+    bytes
+}
+
+#[test]
+fn known_answers() {
+    let empty: [u8; OUTPUT_SIZE] = [
+        0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c, 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03,
+        0xc0, 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85,
+        0xa4, 0x70,
+    ];
+    assert_eq!(keccak256(&[]), empty);
+
+    let abc: [u8; OUTPUT_SIZE] = [
+        0x4e, 0x03, 0x65, 0x7a, 0xea, 0x45, 0xa9, 0x4f, 0xc7, 0xd4, 0x7b, 0xa8, 0x26, 0xc8, 0xd6,
+        0x67, 0xc0, 0xd1, 0xe6, 0xe3, 0x3a, 0x64, 0xa0, 0x36, 0xec, 0x44, 0xf5, 0x8f, 0xa1, 0x2d,
+        0x6c, 0x45,
+    ];
+    assert_eq!(keccak256(b"abc"), abc);
+}
+
+#[test]
+fn matches_reference_across_lengths() {
+    // Covers both sides of every rate-block and 8-byte-word boundary.
+    for len in 0..=420 {
+        let bytes = test_bytes(len, 0x1234_5678 + len as u64);
+        assert_eq!(keccak256(&bytes), reference(&bytes), "length {len}");
+    }
+    for len in [1000, 4096, 100_000] {
+        let bytes = test_bytes(len, len as u64);
+        assert_eq!(keccak256(&bytes), reference(&bytes), "length {len}");
+    }
+}
+
+#[test]
+fn matches_reference_at_unaligned_offsets() {
+    let bytes = test_bytes(4400, 42);
+    for offset in 0..16 {
+        for len in [0, 1, 20, 32, 135, 136, 137, 300, 4000] {
+            let slice = &bytes[offset..offset + len];
+            assert_eq!(keccak256(slice), reference(slice), "offset {offset} length {len}");
+        }
+    }
+}
+
+#[test]
+fn streaming_absorb_matches_one_shot() {
+    let bytes = test_bytes(1500, 7);
+    for chunk_size in [1, 3, 7, 8, 64, 135, 136, 137, 500] {
+        let mut sponge = Keccak256Sponge::new();
+        for chunk in bytes.chunks(chunk_size) {
+            sponge.absorb(chunk);
+        }
+        assert_eq!(sponge.absorbed_len(), bytes.len());
+        assert_eq!(sponge.finalize(), reference(&bytes), "chunk size {chunk_size}");
+    }
+}
+
+#[test]
+fn bufmut_writes_match_one_shot() {
+    let bytes = test_bytes(700, 99);
+    let mut sponge = Keccak256Sponge::new();
+    let mut written = 0;
+    // Alternate single-byte and slice writes of growing sizes.
+    let mut len = 1;
+    while written < bytes.len() {
+        sponge.put_u8(bytes[written]);
+        written += 1;
+        let take = usize::min(len, bytes.len() - written);
+        sponge.put_slice(&bytes[written..written + take]);
+        written += take;
+        len += 13;
+    }
+    assert_eq!(sponge.absorbed_len(), bytes.len());
+    assert_eq!(sponge.finalize(), reference(&bytes));
+}
+
+#[test]
+fn chunk_mut_writes_match_one_shot() {
+    let bytes = test_bytes(1000, 5);
+    let mut sponge = Keccak256Sponge::new();
+    let mut written = 0;
+    let mut step = 1;
+    while written < bytes.len() {
+        let chunk = sponge.chunk_mut();
+        let take = usize::min(usize::min(step, chunk.len()), bytes.len() - written);
+        // SAFETY: `take` is bounded by both the chunk and the source lengths, and
+        // `advance_mut` is passed exactly the number of initialized bytes.
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes[written..].as_ptr(), chunk.as_mut_ptr(), take);
+            sponge.advance_mut(take);
+        }
+        written += take;
+        step += 3;
+    }
+    assert_eq!(sponge.absorbed_len(), bytes.len());
+    assert_eq!(sponge.finalize(), reference(&bytes));
+}

--- a/crates/guest-keccak/tests/differential.rs
+++ b/crates/guest-keccak/tests/differential.rs
@@ -10,6 +10,15 @@ fn reference(bytes: &[u8]) -> [u8; OUTPUT_SIZE] {
     digest
 }
 
+/// Keccak-256 rate in bytes, mirroring the sponge's own internal constant. Its block boundaries
+/// are where the absorb state machine changes behaviour, so the sweeps below are expressed
+/// relative to it.
+const RATE: usize = 136;
+
+/// Alignment the sponge maintains for buffers handed to the OpenVM instructions, mirroring its
+/// internal constant.
+const GUEST_ALIGN: usize = 8;
+
 /// Deterministic pseudo-random bytes (xorshift), independent of test order.
 fn test_bytes(len: usize, mut seed: u64) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(len);
@@ -105,6 +114,9 @@ fn chunk_mut_writes_match_one_shot() {
     while written < bytes.len() {
         let chunk = sponge.chunk_mut();
         let take = usize::min(usize::min(step, chunk.len()), bytes.len() - written);
+        // Fail rather than spin if `chunk_mut` ever hands back an empty slice, which is what it
+        // does whenever it stops flushing a full block.
+        assert_ne!(take, 0, "chunk_mut returned no room at {written} bytes written");
         // SAFETY: `take` is bounded by both the chunk and the source lengths, and
         // `advance_mut` is passed exactly the number of initialized bytes.
         unsafe {
@@ -116,4 +128,80 @@ fn chunk_mut_writes_match_one_shot() {
     }
     assert_eq!(sponge.absorbed_len(), bytes.len());
     assert_eq!(sponge.finalize(), reference(&bytes));
+}
+
+/// Enumerates the absorb state machine's transition table: every `fill` the sponge can hold,
+/// against every following input length that selects a different branch.
+///
+/// [`streaming_absorb_matches_one_shot`] absorbs at a constant chunk size, so the `fill` it
+/// presents to `absorb` only ever visits an arithmetic progression — a chunk size of 8 never
+/// produces a fill of 3. Enumerating the pair leaves no combination unvisited.
+#[test]
+fn absorb_matches_reference_from_every_fill() {
+    let source = test_bytes(3 * RATE, 0xfeed);
+    for prefix in 0..=RATE {
+        for len in 0..=RATE + 8 {
+            let mut sponge = Keccak256Sponge::new();
+            sponge.absorb(&source[..prefix]);
+            sponge.absorb(&source[prefix..prefix + len]);
+            assert_eq!(sponge.absorbed_len(), prefix + len, "prefix {prefix} len {len}");
+            assert_eq!(
+                sponge.finalize(),
+                reference(&source[..prefix + len]),
+                "prefix {prefix} len {len}"
+            );
+        }
+    }
+}
+
+/// The sponge absorbs rate-sized chunks straight from the caller's buffer when their pointer is
+/// 8-byte aligned, so that choice has to be swept against alignment as well as against `fill`.
+///
+/// A host run executes the byte-wise stand-in rather than the XORIN instruction, and the stand-in
+/// tolerates any alignment. What makes this test meaningful off-target is that `xorin` asserts its
+/// length and alignment preconditions for both targets, so admitting a block the instruction could
+/// not accept fails here.
+#[test]
+fn absorb_matches_reference_across_alignments_and_fills() {
+    let source = test_bytes(4 * RATE, 0xa11c);
+    for align_off in 0..GUEST_ALIGN {
+        for prefix in 0..=RATE {
+            for len in [RATE - 1, RATE, RATE + 1, 2 * RATE] {
+                let start = align_off + prefix;
+                let mut sponge = Keccak256Sponge::new();
+                sponge.absorb(&source[align_off..start]);
+                sponge.absorb(&source[start..start + len]);
+                assert_eq!(
+                    sponge.finalize(),
+                    reference(&source[align_off..start + len]),
+                    "align {align_off} prefix {prefix} len {len}"
+                );
+            }
+        }
+    }
+}
+
+/// `put_u8` and `chunk_mut` write into the staged block directly, so the `flush_if_full` each one
+/// performs is what keeps it in bounds when a previous write landed exactly on a block boundary.
+/// `absorb` stages an exact fit without flushing, so that state is reachable — and no other test
+/// here produces it.
+#[test]
+fn block_boundary_writes_stay_in_bounds() {
+    let source = test_bytes(2 * RATE, 0xb10c);
+    // Every split reaches an exactly-full block by a different route through `absorb`.
+    for split in 0..=RATE {
+        let mut sponge = Keccak256Sponge::new();
+        sponge.put_slice(&source[..split]);
+        sponge.put_slice(&source[split..RATE]);
+        assert_eq!(sponge.absorbed_len(), RATE, "split {split}");
+        sponge.put_u8(source[RATE]);
+        sponge.put_slice(&source[RATE + 1..RATE + 9]);
+        assert_eq!(sponge.absorbed_len(), RATE + 9, "split {split}");
+        assert_eq!(sponge.finalize(), reference(&source[..RATE + 9]), "split {split}");
+
+        let mut sponge = Keccak256Sponge::new();
+        sponge.put_slice(&source[..split]);
+        sponge.put_slice(&source[split..RATE]);
+        assert_ne!(sponge.chunk_mut().len(), 0, "chunk_mut found no room, split {split}");
+    }
 }

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 [dependencies]
 serde.workspace = true
 thiserror.workspace = true
+openvm-guest-keccak.workspace = true
 smallvec.workspace = true
 bumpalo = { workspace = true, features = ["collections"] }
 bytes.workspace = true

--- a/crates/mpt/src/state.rs
+++ b/crates/mpt/src/state.rs
@@ -2,8 +2,9 @@ use alloc::{vec, vec::Vec};
 
 use alloy_trie::TrieAccount;
 use bumpalo::Bump;
+use openvm_guest_keccak::keccak256;
 use revm::database::BundleState;
-use revm_primitives::{keccak256, map::DefaultHashBuilder, HashMap, B256};
+use revm_primitives::{map::DefaultHashBuilder, HashMap, B256};
 
 use crate::{Error, Mpt};
 
@@ -45,7 +46,7 @@ impl<'a> EthereumState<'a> {
         // removals must happen last, otherwise unresolved orphans might still exist
         let mut removed_accounts = vec![];
         for (address, account) in &bundle_state.state {
-            let hashed_address = keccak256(address);
+            let hashed_address = B256::new(keccak256(address.as_slice()));
 
             let Some(info) = &account.info else {
                 removed_accounts.push(hashed_address);
@@ -61,7 +62,7 @@ impl<'a> EthereumState<'a> {
 
             let mut removed_slots = vec![];
             for (slot, value) in &account.storage {
-                let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                let hashed_slot = B256::new(keccak256(&slot.to_be_bytes::<32>()));
                 if !value.present_value.is_zero() {
                     storage_trie.insert_rlp(hashed_slot.as_slice(), value.present_value)?;
                 } else {

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -1,14 +1,11 @@
 use alloc::vec::Vec;
-use core::{
-    alloc::Layout,
-    cell::{Cell, RefCell},
-    mem::MaybeUninit,
-};
+use core::{alloc::Layout, cell::Cell, mem::MaybeUninit};
 
 use alloy_rlp::Encodable;
 use bumpalo::Bump;
 use bytes::Buf;
-use revm_primitives::{keccak256, B256};
+use openvm_guest_keccak::{keccak256, Keccak256Sponge};
+use revm_primitives::B256;
 use smallvec::SmallVec;
 
 use crate::{
@@ -22,9 +19,6 @@ use crate::{
 
 /// OpenVM memory alignment word size.
 const MIN_ALIGN: usize = 4;
-
-/// Initial capacity of [`MptTrie`]'s `rlp_scratch`.
-const RLP_SCRATCH_INIT_CAPACITY: usize = 600;
 
 /// Length of a node reference that is a keccak digest rather than the node's own encoding.
 const DIGEST_LEN: usize = 32;
@@ -65,10 +59,6 @@ pub struct Mpt<'a> {
     /// Cache. Hashing/encoding often needs "what would this node look like in its parent"
     cached_references: Vec<Cell<Option<NodeRef<'a>>>>,
 
-    /// Scratch buffer used only for RLP encoding when a node's full RLP exceeds 32 bytes and we
-    /// need to compute its keccak hash. Keeping it here avoids repeated allocations.
-    rlp_scratch: RefCell<Vec<u8>>,
-
     /// Bump allocation area.
     bump: &'a Bump,
 }
@@ -88,13 +78,7 @@ impl<'a> Mpt<'a> {
         nodes.push(NodeData::Null);
         cached_references.push(Cell::new(None));
 
-        Self {
-            nodes,
-            rlp_scratch: RefCell::new(Vec::with_capacity(RLP_SCRATCH_INIT_CAPACITY)),
-            cached_references,
-            bump,
-            root_id: 0,
-        }
+        Self { nodes, cached_references, bump, root_id: 0 }
     }
 }
 
@@ -450,18 +434,14 @@ impl<'a> Mpt<'a> {
 
                     NodeRef::Bytes(encoded.into_inner().into_bump_slice())
                 } else {
-                    let mut scratch = self.rlp_scratch.borrow_mut();
-                    scratch.clear();
+                    // Stream the RLP encoding straight into the hash, so the node bytes are
+                    // never materialized in a scratch buffer.
+                    let mut sponge = Keccak256Sponge::new();
+                    self.encode_with_payload_len(node_id, payload_length, &mut sponge);
+                    debug_assert_eq!(sponge.absorbed_len(), rlp_length);
 
-                    self.encode_with_payload_len(node_id, payload_length, &mut *scratch);
-                    debug_assert_eq!(scratch.len(), rlp_length);
-
-                    let digest = keccak256(&*scratch);
-                    // [shayanh]: This copy could have been avoided if we had allocated keccak's output
-                    // in the bump area from the beginning. This needs to have a
-                    // separate keccak implementation. Since I wanted to stick
-                    // to alloy's keccak, I didn't create a new one.
-                    let digest_slice = self.bump.alloc_slice_copy(digest.as_slice());
+                    let digest = sponge.finalize();
+                    let digest_slice = self.bump.alloc_slice_copy(&digest);
                     NodeRef::Digest(digest_slice)
                 }
             }
@@ -585,7 +565,7 @@ impl<'a> Mpt<'a> {
                 };
                 match node_ref {
                     NodeRef::Digest(digest) => B256::from_slice(digest),
-                    NodeRef::Bytes(bytes) => keccak256(bytes),
+                    NodeRef::Bytes(bytes) => B256::new(keccak256(bytes)),
                 }
             }
         }

--- a/crates/stateless-executor/Cargo.toml
+++ b/crates/stateless-executor/Cargo.toml
@@ -40,6 +40,7 @@ alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 alloy-consensus = { workspace = true, features = ["crypto-backend", "serde-bincode-compat"] }
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
+openvm-guest-keccak.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["reth-ethereum-primitives"]

--- a/crates/stateless-executor/src/io.rs
+++ b/crates/stateless-executor/src/io.rs
@@ -7,6 +7,7 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
 use bumpalo::Bump;
 use itertools::Itertools;
+use openvm_guest_keccak::keccak256;
 use openvm_mpt::{EthereumState, EthereumStateBytes, Mpt};
 use reth_ethereum_primitives::Block;
 use reth_evm::execute::ProviderError;
@@ -14,7 +15,7 @@ use revm::{
     state::{AccountInfo, Bytecode},
     DatabaseRef,
 };
-use revm_primitives::{keccak256, map::DefaultHashBuilder, Address, HashMap, B256, U256};
+use revm_primitives::{map::DefaultHashBuilder, Address, HashMap, B256, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -312,7 +313,7 @@ impl DatabaseRef for WitnessDb<'_, '_> {
 
     /// Get basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let hashed_address = keccak256(address);
+        let hashed_address = B256::new(keccak256(address.as_slice()));
 
         let account_in_trie = self
             .inner
@@ -343,13 +344,13 @@ impl DatabaseRef for WitnessDb<'_, '_> {
     ///
     /// Returns `U256::ZERO` if the slot is not found in the trie.
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let hashed_address = keccak256(address);
+        let hashed_address = B256::new(keccak256(address.as_slice()));
 
         let storage_trie = self.inner.storage_tries.get(&hashed_address).ok_or_else(|| {
             ProviderError::TrieWitnessError(format!("storage trie for {address} not found"))
         })?;
 
-        let hashed_slot = keccak256(index.to_be_bytes::<32>());
+        let hashed_slot = B256::new(keccak256(&index.to_be_bytes::<32>()));
         let storage_value = storage_trie
             .get_rlp::<U256>(hashed_slot.as_slice())
             .map_err(trie_error_to_provider_error)?


### PR DESCRIPTION
Adds an 8-byte-aligned guest Keccak sponge that emits XORIN/KECCAKF directly and implements `BufMut`, allowing MPT reference RLP to stream into the hash without `rlp_scratch`. MPT decode/update hashing and witness-db address/slot hashing use the same one-shot path, avoiding the checked wrapper's alignment allocations and copies. The sponge maintains the native instruction alignment and length requirements internally.

The win is per hash *call*, not per permutation — the permutation count is unchanged, so this does not touch `KeccakfPermAir`. What it removes is the software bookkeeping around every absorb: the 200-byte state reset, the staging copies the checked wrapper makes when a pointer or length is not 8-aligned, and that wrapper's own alignment checks. With hundreds of thousands of hashes per block, those per-call constants dominate.

Differential coverage compares known answers, boundary lengths, unaligned inputs, streaming writes, and the raw `BufMut` path against `tiny-keccak`, plus a sweep enumerating the absorb state machine's transition table — every staged `fill` against every following input length — since sampling uniform chunk sizes only ever visits fills in an arithmetic progression.

That coverage was checked by mutation rather than assumed: each guard was disabled in turn to see whether the suite noticed. Three changes initially slipped through. Two were unchecked preconditions — the XORIN length and alignment assertions sat inside the guest-only `xorin`, so host runs never exercised the contract the instruction depends on, and they now live in a shared wrapper above the target-gated bodies. The third was `put_u8`, whose write into the staged block is bounded only by the flush above it, which no test had presented with a full block. Eight of nine mutations are now caught; the one survivor absorbs an exact-fit block eagerly instead of lazily, which no observer can distinguish. Both fixes are `debug_assert`s, so the measured numbers below are unaffected.

See [Claude's explainer artifact](https://claude.ai/code/artifact/9f74ad67-ec7a-4fcd-9775-741b646aa74c) for more details.

## Benchmark results

Both blocks measured against `develop-v2.1.0` at the same commit, execute-metered.

### Block 24001988

[`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30337379044):

| metric | `develop-v2.1.0` | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 588,618,511 | 575,132,344 | **−13,486,167 (−2.291%)** |
| `metered_rows_unpadded` | 844,070,559 | 820,155,810 | −23,914,749 (−2.833%) |
| `metered_main_cells_unpadded` | 43,260,383,096 | 42,177,994,061 | **−1,082,389,035 (−2.502%)** |
| `metered_interaction_cells_unpadded` | 13,194,454,796 | 12,875,875,956 | −318,578,840 (−2.414%) |
| `metered_memory_unpadded_bytes` | 713,961,114,662 | 699,779,237,587 | −14,181,877,075 (−1.986%) |
| app segments | 65 | 63 | **−2** |

### Block 24002549

[`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342761467) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342763863):

| metric | `develop-v2.1.0` | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 527,179,427 | 515,190,361 | **−11,989,066 (−2.274%)** |
| `metered_rows_unpadded` | 759,879,792 | 737,715,207 | −22,164,585 (−2.917%) |
| `metered_main_cells_unpadded` | 39,410,659,691 | 38,402,408,673 | **−1,008,251,018 (−2.558%)** |
| `metered_interaction_cells_unpadded` | 11,846,946,557 | 11,563,307,133 | −283,639,424 (−2.394%) |
| `metered_memory_unpadded_bytes` | 646,441,525,015 | 633,407,491,239 | −13,034,033,776 (−2.016%) |
| app segments | 59 | 57 | **−2** |

The two blocks agree to within 0.02% on instructions and each drop exactly two segments, so the win does not depend on block shape. The memory reduction is the checked wrapper's staging buffers going away: they were allocated through the guest bump allocator, where deallocation is a no-op, so every unaligned absorb permanently grew the heap.

## Relationship to openvm#3070

[openvm#3070](https://github.com/openvm-org/openvm/pull/3070) rewrites `native_xorin`'s unaligned fallback so it allocates nothing. The two changes are complementary rather than overlapping: this PR takes the MPT's hashing off the wrapper entirely, while openvm#3070 improves the wrapper for everything still going through it — the EVM `KECCAK256` opcode and transaction/header hashing inside revm, which reach it via the alloy `native-keccak` hook. Neither blocks the other, and openvm#3070's contract is unchanged, so landing it needs only a patch revision bump here.

