### PR TITLE
perf(mpt): hash decoded roots once

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -257,28 +257,7 @@ impl<'a> Mpt<'a> {
         let capacity = num_nodes + (num_nodes / 2);
         let mut trie = Self::with_capacity(bump, capacity);
 
-        // construct the expected root reference
-        let root_ref = {
-            let mut buf = *bytes;
-            let rlp_node_header_start = buf;
-            let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(&mut buf)?;
-            // SAFETY: we already decoded the header, so we know the payload length.
-            let payload = unsafe { advance_unchecked(&mut buf, payload_length) };
-            let rlp_node_length = rlp_node_header_start.len() - buf.len();
-
-            let rlp_node = &rlp_node_header_start[..rlp_node_length];
-            if rlp_node.len() < 32 {
-                NodeRef::Bytes(rlp_node)
-            } else if !list {
-                NodeRef::Digest(payload)
-            } else {
-                let digest = keccak256(rlp_node);
-                let digest_slice = bump.alloc_slice_copy(digest.as_slice());
-                NodeRef::Digest(digest_slice)
-            }
-        };
-
-        let root_id = trie.decode_trie_internal(bytes, root_ref)?;
+        let root_id = trie.decode_trie_internal(bytes, None)?;
         trie.root_id = root_id;
 
         Ok(trie)
@@ -287,7 +266,7 @@ impl<'a> Mpt<'a> {
     fn decode_trie_internal(
         &mut self,
         bytes: &mut &'a [u8],
-        expected_node_ref: NodeRef<'a>,
+        expected_node_ref: Option<NodeRef<'a>>,
     ) -> Result<NodeId, Error> {
         // Unresolved nodes are encoded as a 32-byte RLP string followed by three alignment bytes.
         // They are common at the witness boundary and have a fixed representation, so avoid the
@@ -298,8 +277,10 @@ impl<'a> Mpt<'a> {
             let encoded = unsafe { advance_unchecked(bytes, 33) };
             unsafe { advance_unchecked(bytes, 3) };
             let digest = &encoded[1..];
-            if !bytes_eq(digest, expected_node_ref.as_slice()) {
-                return Err(Error::NodeRefMismatch);
+            if let Some(expected_node_ref) = expected_node_ref {
+                if !bytes_eq(digest, expected_node_ref.as_slice()) {
+                    return Err(Error::NodeRefMismatch);
+                }
             }
             return Ok(self.add_node(NodeData::Digest(digest), Some(NodeRef::Digest(digest))));
         }
@@ -317,24 +298,35 @@ impl<'a> Mpt<'a> {
         // SAFETY: we expect the padding. See the `encode_trie_internal` function.
         unsafe { advance_unchecked(bytes, padding_len) };
 
-        // calculate node's reference and ensure it matches the `expected_node_ref` from parent.
+        // Calculate the node's reference and, for non-root nodes, ensure it matches the reference
+        // embedded in the parent.
         let node_ref = {
             if rlp_node_length < 32 {
-                if !bytes_eq(rlp_node, expected_node_ref.as_slice()) {
-                    return Err(Error::NodeRefMismatch);
+                let node_ref = NodeRef::Bytes(rlp_node);
+                if let Some(expected_node_ref) = expected_node_ref {
+                    if !bytes_eq(node_ref.as_slice(), expected_node_ref.as_slice()) {
+                        return Err(Error::NodeRefMismatch);
+                    }
                 }
-                NodeRef::Bytes(rlp_node)
+                node_ref
             } else if payload_length == 32 && !list {
-                if !bytes_eq(payload, expected_node_ref.as_slice()) {
-                    return Err(Error::NodeRefMismatch);
+                let node_ref = NodeRef::Digest(payload);
+                if let Some(expected_node_ref) = expected_node_ref {
+                    if !bytes_eq(node_ref.as_slice(), expected_node_ref.as_slice()) {
+                        return Err(Error::NodeRefMismatch);
+                    }
                 }
-                expected_node_ref
+                node_ref
             } else {
                 let digest = keccak256(rlp_node);
-                if !bytes_eq(digest.as_slice(), expected_node_ref.as_slice()) {
-                    return Err(Error::NodeRefMismatch);
+                if let Some(expected_node_ref) = expected_node_ref {
+                    if !bytes_eq(digest.as_slice(), expected_node_ref.as_slice()) {
+                        return Err(Error::NodeRefMismatch);
+                    }
+                    expected_node_ref
+                } else {
+                    NodeRef::Digest(self.bump.alloc_slice_copy(&digest))
                 }
-                expected_node_ref
             }
         };
 
@@ -359,7 +351,7 @@ impl<'a> Mpt<'a> {
             if (prefix & (2 << 4)) == 0 {
                 // extension node
                 let ext_node_expected_ref = NodeRef::from_rlp_slice(item1);
-                let ext_node_id = self.decode_trie_internal(bytes, ext_node_expected_ref)?;
+                let ext_node_id = self.decode_trie_internal(bytes, Some(ext_node_expected_ref))?;
                 let node_data = NodeData::Extension(path, ext_node_id);
                 return Ok(self.add_node(node_data, Some(node_ref)));
             } else {
@@ -375,7 +367,9 @@ impl<'a> Mpt<'a> {
                 None
             } else {
                 let child0_expected_node_ref = NodeRef::from_rlp_slice(item0);
-                Some(branch_child_id(self.decode_trie_internal(bytes, child0_expected_node_ref)?))
+                Some(branch_child_id(
+                    self.decode_trie_internal(bytes, Some(child0_expected_node_ref))?,
+                ))
             }
         };
 
@@ -384,7 +378,9 @@ impl<'a> Mpt<'a> {
                 None
             } else {
                 let child1_expected_node_ref = NodeRef::from_rlp_slice(item1);
-                Some(branch_child_id(self.decode_trie_internal(bytes, child1_expected_node_ref)?))
+                Some(branch_child_id(
+                    self.decode_trie_internal(bytes, Some(child1_expected_node_ref))?,
+                ))
             }
         };
 
@@ -415,7 +411,7 @@ impl<'a> Mpt<'a> {
                 } else {
                     let child_expected_node_ref = NodeRef::from_rlp_slice(item);
                     Some(branch_child_id(
-                        self.decode_trie_internal(bytes, child_expected_node_ref)?,
+                        self.decode_trie_internal(bytes, Some(child_expected_node_ref))?,
                     ))
                 }
             });


### PR DESCRIPTION
Stacked on #668.

`decode_trie` currently hashes the root to construct an expected reference, then `decode_trie_internal` parses and hashes the same root again to verify it against itself. Decode the root without a parent reference and calculate its reference once; child references retain the existing validation.

## Benchmark results

Block 24001988, RVR execution: [#668](https://github.com/axiom-crypto/openvm-eth/actions/runs/29826957702), [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/29833963927).

| metric | #668 | this PR | delta |
| --- | ---: | ---: | ---: |
| instructions | 616,699,072 | 617,840,249 | +1,141,177 (+0.19%) |
| rows (unpadded) | 885,302,449 | 886,426,462 | +1,124,013 (+0.13%) |
| main cells (unpadded) | 45,292,782,124 | 45,331,501,327 | +38,719,203 (+0.09%) |
| interaction cells (unpadded) | 13,866,568,650 | 13,904,709,644 | +38,140,994 (+0.28%) |
| memory (unpadded bytes) | 737,157,581,407 | 737,704,346,019 | +546,764,612 (+0.07%) |
| segment triggers | 68 | 68 | 0 |

### Block 24003902

RVR execution: [#668](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838162550), [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/29838164775).

| metric | #668 | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 504,768,785 | 504,956,541 | +187,756 (+0.04%) |
| `metered_rows_unpadded` | 681,073,282 | 681,236,018 | +162,736 (+0.02%) |
| `metered_main_cells_unpadded` | 29,632,751,295 | 29,605,208,955 | −27,542,340 (−0.09%) |
| `metered_interaction_cells_unpadded` | 11,832,283,506 | 11,839,349,260 | +7,065,754 (+0.06%) |
| `metered_memory_unpadded_bytes` | 568,582,392,692 | 568,276,945,110 | −305,447,582 (−0.05%) |
| memory-triggered segment cuts | 50 | 50 | 0 |