### PR TITLE
perf(kzg): execute test vectors instead of proving each one

### DIFF
--- a/.github/workflows/label-overrides.yml
+++ b/.github/workflows/label-overrides.yml
@@ -1,0 +1,14 @@
+name: Label overrides
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  kzg-proving:
+    if: ${{ github.event.label.name == 'run-kzg-proving' }}
+    uses: ./.github/workflows/tests-kzg.yml
+    secrets: inherit

--- a/.github/workflows/tests-kzg.yml
+++ b/.github/workflows/tests-kzg.yml
@@ -1,6 +1,7 @@
 name: OpenVM KZG Tests
 
 on:
+  workflow_call:
   push:
     branches: ["main"]
     paths:
@@ -10,7 +11,6 @@ on:
       - "Cargo.lock"
       - ".github/workflows/tests-kzg.yml"
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/kzg/**"
       - "crates/curve-utils/**"
@@ -30,6 +30,7 @@ env:
 
 jobs:
   test:
+    if: ${{ github.event.action != 'labeled' }}
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=64cpu-linux-arm64
@@ -61,6 +62,35 @@ jobs:
       - name: Run tests
         run: cargo nextest run -p openvm-kzg --release
 
+  # Proves every valid test vector. Runs on pushes to main and on PRs with
+  # the run-kzg-proving label (see label-overrides.yml).
+  prove-all:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-kzg-proving') }}
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=64cpu-linux-arm64
+      - extras=s3-cache
+
+    steps:
+      - uses: runs-on/action@v2
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@nextest
+      - name: Restore openvm toolchain from cache
+        uses: runs-on/cache@v4
+        with:
+          path: ~/.openvm/toolchains
+          key: openvm-toolchain-openvm-1.94.0-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install OpenVM guest toolchain
+        run: |
+          rustup install nightly-2026-01-18
+          rustup component add rust-src --toolchain nightly-2026-01-18
+          cargo install --git https://github.com/openvm-org/openvm.git --branch "$OPENVM_BRANCH" --locked --force cargo-openvm
+          cargo openvm toolchain install
+
       - name: Prove all test vectors
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-kzg-proving')
         run: cargo nextest run -p openvm-kzg --release --run-ignored ignored-only test_prove_multiple_valid_verify_kzg

--- a/.github/workflows/tests-kzg.yml
+++ b/.github/workflows/tests-kzg.yml
@@ -10,6 +10,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/tests-kzg.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/kzg/**"
       - "crates/curve-utils/**"
@@ -59,3 +60,7 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run -p openvm-kzg --release
+
+      - name: Prove all test vectors
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-kzg-prove-all')
+        run: cargo nextest run -p openvm-kzg --release --run-ignored ignored-only test_prove_multiple_valid_verify_kzg

--- a/.github/workflows/tests-kzg.yml
+++ b/.github/workflows/tests-kzg.yml
@@ -62,5 +62,5 @@ jobs:
         run: cargo nextest run -p openvm-kzg --release
 
       - name: Prove all test vectors
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-full-proving')
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-kzg-proving')
         run: cargo nextest run -p openvm-kzg --release --run-ignored ignored-only test_prove_multiple_valid_verify_kzg

--- a/.github/workflows/tests-kzg.yml
+++ b/.github/workflows/tests-kzg.yml
@@ -62,5 +62,5 @@ jobs:
         run: cargo nextest run -p openvm-kzg --release
 
       - name: Prove all test vectors
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-kzg-prove-all')
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-full-proving')
         run: cargo nextest run -p openvm-kzg --release --run-ignored ignored-only test_prove_multiple_valid_verify_kzg

--- a/.github/workflows/tests-kzg.yml
+++ b/.github/workflows/tests-kzg.yml
@@ -93,4 +93,4 @@ jobs:
           cargo openvm toolchain install
 
       - name: Prove all test vectors
-        run: cargo nextest run -p openvm-kzg --release --run-ignored ignored-only test_prove_multiple_valid_verify_kzg
+        run: cargo nextest run -p openvm-kzg --release --run-ignored only test_prove_multiple_valid_verify_kzg

--- a/crates/kzg/README.md
+++ b/crates/kzg/README.md
@@ -5,12 +5,14 @@
 To run the guest tests, run:
 
 ```bash
-# Proves a single test vector through the full app proving pipeline:
+# Prove a single test vector:
 cargo test --release test_single_valid_verify_kzg -- --show-output
 # Execute (without proving) all valid and invalid test vectors:
 cargo test --release test_multiple_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_invalid_verify_kzg -- --show-output
 cargo test --release test_single_invalid_verify_kzg -- --show-output
+# Prove all valid test vectors (in CI: pushes to main or the run-kzg-prove-all PR label):
+cargo test --release test_prove_multiple_valid_verify_kzg -- --ignored --show-output
 ```
 
 ## Crates

--- a/crates/kzg/README.md
+++ b/crates/kzg/README.md
@@ -2,14 +2,15 @@
 
 ## Quickstart
 
-To run guest tests with OpenVM proving, run:
+To run the guest tests, run:
 
 ```bash
+# Proves a single test vector through the full app proving pipeline:
 cargo test --release test_single_valid_verify_kzg -- --show-output
+# Execute (without proving) all valid and invalid test vectors:
 cargo test --release test_multiple_valid_verify_kzg -- --show-output
+cargo test --release test_multiple_invalid_verify_kzg -- --show-output
 cargo test --release test_single_invalid_verify_kzg -- --show-output
-# The following takes longer:
-cargo test --release --ignored test_multiple_invalid_verify_kzg -- --show-output
 ```
 
 ## Crates

--- a/crates/kzg/README.md
+++ b/crates/kzg/README.md
@@ -11,7 +11,7 @@ cargo test --release test_single_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_invalid_verify_kzg -- --show-output
 cargo test --release test_single_invalid_verify_kzg -- --show-output
-# Prove all valid test vectors (in CI: pushes to main or the run-full-proving PR label):
+# Prove all valid test vectors (in CI: pushes to main or the run-kzg-proving PR label):
 cargo test --release test_prove_multiple_valid_verify_kzg -- --ignored --show-output
 ```
 

--- a/crates/kzg/README.md
+++ b/crates/kzg/README.md
@@ -11,7 +11,7 @@ cargo test --release test_single_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_invalid_verify_kzg -- --show-output
 cargo test --release test_single_invalid_verify_kzg -- --show-output
-# Prove all valid test vectors (in CI: pushes to main or the run-kzg-prove-all PR label):
+# Prove all valid test vectors (in CI: pushes to main or the run-full-proving PR label):
 cargo test --release test_prove_multiple_valid_verify_kzg -- --ignored --show-output
 ```
 

--- a/crates/kzg/README.md
+++ b/crates/kzg/README.md
@@ -11,7 +11,7 @@ cargo test --release test_single_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_valid_verify_kzg -- --show-output
 cargo test --release test_multiple_invalid_verify_kzg -- --show-output
 cargo test --release test_single_invalid_verify_kzg -- --show-output
-# Prove all valid test vectors (in CI: pushes to main or the run-kzg-proving PR label):
+# Prove all valid test vectors (expensive):
 cargo test --release test_prove_multiple_valid_verify_kzg -- --ignored --show-output
 ```
 

--- a/crates/kzg/tests/integration_tests.rs
+++ b/crates/kzg/tests/integration_tests.rs
@@ -10,44 +10,68 @@ use openvm_kzg::{
 };
 use openvm_sdk::{
     config::{AggregationSystemParams, AppConfig},
-    Sdk, StdIn,
+    CompiledExePure, ExecutableFormat, Sdk, StdIn,
 };
 use openvm_sdk_config::SdkVmConfig;
 use openvm_stark_sdk::utils::setup_tracing;
 use serde_yaml::from_str;
 
+/// Proves a single test vector, covering the full app proving pipeline.
 #[test]
 fn test_single_valid_verify_kzg() {
     let (_, data) = SINGLE_VALID_KZG_PROOF_TEST[0];
-    run_test_from_yaml_str(data);
+    let sdk = create_sdk();
+    let elf = build_guest(&sdk);
+    let input = parse_inputs(data).expect("Invalid test inputs");
+    sdk.app_prover(elf).unwrap().prove(stdin(&input)).unwrap();
 }
 
+/// Executes (without proving) every valid test vector against a guest built
+/// and compiled once.
 #[test]
 fn test_multiple_valid_verify_kzg() {
+    let sdk = create_sdk();
+    let elf = build_guest(&sdk);
+    let compiled = sdk.compile(elf).unwrap();
     for (test_file, data) in ONLY_VALID_KZG_PROOF_TESTS {
         println!("Running test: {}", test_file);
-        run_test_from_yaml_str(data);
+        let input = parse_inputs(data).expect("Invalid test inputs");
+        sdk.execute(&compiled, stdin(&input))
+            .unwrap_or_else(|err| panic!("Test {} failed: {}", test_file, err));
     }
 }
 
 #[test]
 fn test_single_invalid_verify_kzg() {
     let (test_file, data) = ONLY_INVALID_KZG_PROOF_TESTS[0];
-    let result = std::panic::catch_unwind(|| run_test_from_yaml_str(data));
-    assert!(result.is_err(), "Test {} should have panicked", test_file);
+    let sdk = create_sdk();
+    let elf = build_guest(&sdk);
+    let compiled = sdk.compile(elf).unwrap();
+    assert_rejected(&sdk, &compiled, test_file, data);
 }
 
-#[ignore = "takes too long"]
 #[test]
 fn test_multiple_invalid_verify_kzg() {
+    let sdk = create_sdk();
+    let elf = build_guest(&sdk);
+    let compiled = sdk.compile(elf).unwrap();
     for (test_file, data) in ONLY_INVALID_KZG_PROOF_TESTS {
         println!("Running test: {}", test_file);
-        let result = std::panic::catch_unwind(|| run_test_from_yaml_str(data));
-        assert!(result.is_err(), "Test {} should have panicked", test_file);
+        assert_rejected(&sdk, &compiled, test_file, data);
     }
 }
 
-pub fn run_test_from_yaml_str(data: &str) {
+/// Asserts that an invalid test vector is rejected, either at input parsing or
+/// by the guest program trapping during execution.
+fn assert_rejected(sdk: &Sdk, compiled: &CompiledExePure<'_>, test_file: &str, data: &str) {
+    let Some(input) = parse_inputs(data) else {
+        return;
+    };
+    let result = sdk.execute(compiled, stdin(&input));
+    assert!(result.is_err(), "Test {} should have failed", test_file);
+}
+
+fn parse_inputs(data: &str) -> Option<KzgInputs> {
     let test: Test<Input<'_>> = from_str(data).unwrap();
     let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (
         test.input.get_commitment(),
@@ -55,21 +79,25 @@ pub fn run_test_from_yaml_str(data: &str) {
         test.input.get_y(),
         test.input.get_proof(),
     ) else {
-        panic!("Invalid test inputs");
+        return None;
     };
-
-    let input =
-        KzgInputs { commitment_bytes: commitment, z_bytes: z, y_bytes: y, proof_bytes: proof };
-
-    run_guest_program(input);
+    Some(KzgInputs { commitment_bytes: commitment, z_bytes: z, y_bytes: y, proof_bytes: proof })
 }
 
-pub fn run_guest_program(input: KzgInputs) {
+fn stdin(input: &KzgInputs) -> StdIn {
+    let mut io = StdIn::default();
+    io.write(input);
+    io
+}
+
+fn create_sdk() -> Sdk {
     setup_tracing();
     let app_config: AppConfig<SdkVmConfig> =
         toml::from_str(include_str!("programs/verify_kzg/openvm.toml")).unwrap();
-    let sdk = Sdk::new(app_config, AggregationSystemParams::default()).unwrap();
+    Sdk::new(app_config, AggregationSystemParams::default()).unwrap()
+}
 
+fn build_guest(sdk: &Sdk) -> ExecutableFormat {
     let guest_opts = GuestOptions::default();
     let target_filter =
         Some(TargetFilter { name: "verify-kzg-program".to_string(), kind: "bin".to_string() });
@@ -77,11 +105,5 @@ pub fn run_guest_program(input: KzgInputs) {
     pkg_dir.push("tests");
     pkg_dir.push("programs");
     pkg_dir.push("verify_kzg");
-
-    let elf = sdk.build(guest_opts, &pkg_dir, &target_filter, None).unwrap();
-
-    let mut io = StdIn::default();
-    io.write(&input);
-
-    sdk.app_prover(elf).unwrap().prove(io).unwrap();
+    sdk.build(guest_opts, &pkg_dir, &target_filter, None).unwrap().into()
 }

--- a/crates/kzg/tests/integration_tests.rs
+++ b/crates/kzg/tests/integration_tests.rs
@@ -39,7 +39,7 @@ fn test_multiple_valid_verify_kzg() {
 }
 
 /// Proves every valid vector with a shared prover so keygen runs once.
-#[ignore = "run via the run-full-proving CI label"]
+#[ignore = "run via the run-kzg-proving CI label"]
 #[test]
 fn test_prove_multiple_valid_verify_kzg() {
     let sdk = create_sdk();

--- a/crates/kzg/tests/integration_tests.rs
+++ b/crates/kzg/tests/integration_tests.rs
@@ -39,7 +39,7 @@ fn test_multiple_valid_verify_kzg() {
 }
 
 /// Proves every valid vector with a shared prover so keygen runs once.
-#[ignore = "run via the run-kzg-prove-all CI label"]
+#[ignore = "run via the run-full-proving CI label"]
 #[test]
 fn test_prove_multiple_valid_verify_kzg() {
     let sdk = create_sdk();

--- a/crates/kzg/tests/integration_tests.rs
+++ b/crates/kzg/tests/integration_tests.rs
@@ -16,7 +16,6 @@ use openvm_sdk_config::SdkVmConfig;
 use openvm_stark_sdk::utils::setup_tracing;
 use serde_yaml::from_str;
 
-/// Proves a single test vector, covering the full app proving pipeline.
 #[test]
 fn test_single_valid_verify_kzg() {
     let (_, data) = SINGLE_VALID_KZG_PROOF_TEST[0];
@@ -26,8 +25,6 @@ fn test_single_valid_verify_kzg() {
     sdk.app_prover(elf).unwrap().prove(stdin(&input)).unwrap();
 }
 
-/// Executes (without proving) every valid test vector against a guest built
-/// and compiled once.
 #[test]
 fn test_multiple_valid_verify_kzg() {
     let sdk = create_sdk();
@@ -38,6 +35,20 @@ fn test_multiple_valid_verify_kzg() {
         let input = parse_inputs(data).expect("Invalid test inputs");
         sdk.execute(&compiled, stdin(&input))
             .unwrap_or_else(|err| panic!("Test {} failed: {}", test_file, err));
+    }
+}
+
+/// Proves every valid vector with a shared prover so keygen runs once.
+#[ignore = "run via the run-kzg-prove-all CI label"]
+#[test]
+fn test_prove_multiple_valid_verify_kzg() {
+    let sdk = create_sdk();
+    let elf = build_guest(&sdk);
+    let mut prover = sdk.app_prover(elf).unwrap();
+    for (test_file, data) in ONLY_VALID_KZG_PROOF_TESTS {
+        println!("Proving test: {}", test_file);
+        let input = parse_inputs(data).expect("Invalid test inputs");
+        prover.prove(stdin(&input)).unwrap();
     }
 }
 
@@ -61,8 +72,7 @@ fn test_multiple_invalid_verify_kzg() {
     }
 }
 
-/// Asserts that an invalid test vector is rejected, either at input parsing or
-/// by the guest program trapping during execution.
+/// Passes if the vector is rejected at input parsing or by the guest trapping.
 fn assert_rejected(sdk: &Sdk, compiled: &CompiledExePure<'_>, test_file: &str, data: &str) {
     let Some(input) = parse_inputs(data) else {
         return;

--- a/crates/kzg/tests/integration_tests.rs
+++ b/crates/kzg/tests/integration_tests.rs
@@ -39,8 +39,8 @@ fn test_multiple_valid_verify_kzg() {
 }
 
 /// Proves every valid vector with a shared prover so keygen runs once.
-#[ignore = "run via the run-kzg-proving CI label"]
 #[test]
+#[ignore = "expensive: proves every valid KZG vector"]
 fn test_prove_multiple_valid_verify_kzg() {
     let sdk = create_sdk();
     let elf = build_guest(&sdk);


### PR DESCRIPTION
## Why

The [tests-kzg workflow](https://github.com/axiom-crypto/openvm-eth/actions/workflows/tests-kzg.yml) takes 25–29 min per run, ~24 min of which is `test_multiple_valid_verify_kzg`: it generated a full app proof for each of the 54 valid KZG vectors, recreating the `Sdk` (guest build + app keygen) per vector on top of the ~25s/vector proving cost.

Proving is the irreducible cost — measurement shows keygen+build is only a few seconds while each proof takes ~25s on the 64-core runner — so the fix is to not prove every vector on every PR, while keeping full proving coverage available.

## What

- `test_multiple_valid_verify_kzg` builds and compiles the guest once, then runs each vector through the SDK's pure-execution path (`sdk.compile` + `sdk.execute`) instead of proving. The guest `assert!`s the verification result, so execution carries the per-vector pass/fail signal for guest logic. **1438s → 4.1s.**
- New `test_prove_multiple_valid_verify_kzg` (`#[ignore]`d by default) proves **all 54 valid vectors** with a shared prover, so keygen runs once. This covers what execution alone cannot: circuit trace generation and proving over the full input range, which can fail on operand edge cases that execute fine. Verified passing locally over all 54 vectors.
- A `prove-all` job runs this test on pushes to `main` and on PRs carrying the **`run-kzg-proving`** label. Following the openvm label-overrides pattern, a new `label-overrides.yml` fires on `labeled` events and invokes `tests-kzg.yml` via `workflow_call`, so adding the label starts the proving job immediately (the fast `test` job is skipped on label events, and unrelated labels don't re-trigger anything).
- `test_single_valid_verify_kzg` still proves one vector on every PR, keeping the proving pipeline smoke-tested.
- Invalid-vector tests assert an execution error (guest trap) instead of wrapping a proving panic in `catch_unwind`; this made `test_multiple_invalid_verify_kzg` — previously `#[ignore = "takes too long"]` — cheap enough to un-ignore, so all 68 invalid vectors now run in CI (42s).

Expected CI time: **~6 min on PRs** (vs ~25 min), with full 54-vector proving on `main` pushes and label-opted PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)