### PR TITLE
ci: install llvm.sh prerequisites before clang-22

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -322,6 +322,9 @@ jobs:
       - name: Install clang-22 and lld
         if: ${{ (inputs.exec_mode || github.event.inputs.exec_mode || 'rvr') == 'rvr' }}
         run: |
+          # llvm.sh requires add-apt-repository, which the runner image does not ship.
+          sudo apt-get update
+          sudo apt-get install -y lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 22


### PR DESCRIPTION
`llvm.sh` now validates its prerequisites up front and exits 4 when `add-apt-repository` is missing:

```
[error] Missing required tools: add-apt-repository
(hint: apt install lsb-release wget software-properties-common gnupg)
```

The benchmark runner image (`ami-0d294fa2de702e7ee`) does not ship `software-properties-common`, so every `rvr`-mode benchmark now fails at `Install clang-22 and lld` before building anything — see [run 30148654865](https://github.com/axiom-crypto/openvm-eth/actions/runs/30148654865) and [run 30148601308](https://github.com/axiom-crypto/openvm-eth/actions/runs/30148601308).

Installs the tools `llvm.sh` asks for first. Only `reth-benchmark.yml` runs `llvm.sh`, and only on the `rvr` path, so this is the whole blast radius.