### PR TITLE
perf(mpt): compare node reference digests as words

### DIFF
--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -232,6 +232,47 @@ fn test_serde_keccak_trie() -> Result<(), Error> {
     Ok(())
 }
 
+/// A child reference that disagrees with the child's own encoding must be rejected. Decoding
+/// compares the two for their whole length, so accepting one would mean accepting a witness that
+/// does not hash to the claimed root. Every byte of the digest is checked, including the last,
+/// which is what a comparison that stopped short would miss.
+#[cfg(feature = "host")]
+#[test]
+fn test_serde_rejects_corrupted_digest_reference() -> Result<(), Error> {
+    const N: usize = 64;
+
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+    for i in 0..N {
+        assert!(trie.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), i)?);
+    }
+    let encoded = trie.encode_trie();
+
+    // Sanity check that the unmodified encoding decodes, so a rejection below is the corruption
+    // and not an unrelated failure.
+    Mpt::decode_trie(&bump, &mut encoded.as_slice(), trie.num_nodes())?;
+
+    // The first 32-byte RLP string in the encoding is a digest reference. Corrupting a byte of
+    // its payload leaves every length in the encoding intact, so the reference comparison is the
+    // only thing that can catch it.
+    let digest_header = alloy_rlp::EMPTY_STRING_CODE + 32;
+    let header_at = encoded.iter().position(|&b| b == digest_header).expect("a digest reference");
+
+    for offset in [1, 16, 32] {
+        let mut corrupted = encoded.clone();
+        corrupted[header_at + offset] ^= 0x01;
+        assert!(
+            matches!(
+                Mpt::decode_trie(&bump, &mut corrupted.as_slice(), trie.num_nodes()),
+                Err(Error::NodeRefMismatch)
+            ),
+            "corrupting digest byte {offset} was not rejected"
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "host")]
 #[test]
 fn test_serde_digest_root() -> Result<(), Error> {

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -20,6 +20,9 @@ use crate::{
 /// OpenVM memory alignment word size.
 const MIN_ALIGN: usize = 4;
 
+/// Length of a node reference that is a keccak digest rather than the node's own encoding.
+const DIGEST_LEN: usize = 32;
+
 /// Sentinel index representing the null node when decoding and in internal references.
 /// In a default MPT, `nodes[0]` starts as `Null`, but the root may later be changed to a
 /// non-null node (e.g. `Digest`) for convenience. `NULL_NODE_ID` is still used by the decoder
@@ -148,12 +151,27 @@ fn is_null_ref(slice: &[u8]) -> bool {
     matches!(slice, [byte] if *byte == alloy_rlp::EMPTY_STRING_CODE)
 }
 
-/// Byte-slice equality as an explicit loop. Slice `==` compiles to a `memcmp` call; the node
-/// references compared during decoding are at most 33 bytes, where the call overhead dominates
-/// an inline loop.
+/// Byte-slice equality as an explicit loop. Slice `==` on slices of unknown length compiles to a
+/// `memcmp` call; the node references compared during decoding are at most 33 bytes, where the
+/// call overhead dominates an inline loop. Prefer [`digest_eq`] whenever one side is a full-length
+/// digest, since a length known at compile time turns the comparison into whole-word loads.
 #[inline(always)]
 fn bytes_eq(a: &[u8], b: &[u8]) -> bool {
     a.len() == b.len() && core::iter::zip(a, b).all(|(x, y)| x == y)
+}
+
+/// Equality against a 32-byte node reference.
+///
+/// Fixing the length lets the comparison stay inline as four word loads per side and an XOR
+/// chain, where a loop over slices of unknown length pays several instructions for every byte.
+/// Slices of different lengths are never equal, so a reference that is not a full digest is
+/// inequality rather than a case to fall back on.
+#[inline(always)]
+fn digest_eq(a: &[u8], b: &[u8]) -> bool {
+    match (<&[u8; DIGEST_LEN]>::try_from(a), <&[u8; DIGEST_LEN]>::try_from(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// Converts a node id to a branch child slot id.
@@ -298,7 +316,7 @@ impl<'a> Mpt<'a> {
             let encoded = unsafe { advance_unchecked(bytes, 33) };
             unsafe { advance_unchecked(bytes, 3) };
             let digest = &encoded[1..];
-            if !bytes_eq(digest, expected_node_ref.as_slice()) {
+            if !digest_eq(digest, expected_node_ref.as_slice()) {
                 return Err(Error::NodeRefMismatch);
             }
             return Ok(self.add_node(NodeData::Digest(digest), Some(NodeRef::Digest(digest))));
@@ -325,13 +343,13 @@ impl<'a> Mpt<'a> {
                 }
                 NodeRef::Bytes(rlp_node)
             } else if payload_length == 32 && !list {
-                if !bytes_eq(payload, expected_node_ref.as_slice()) {
+                if !digest_eq(payload, expected_node_ref.as_slice()) {
                     return Err(Error::NodeRefMismatch);
                 }
                 expected_node_ref
             } else {
                 let digest = keccak256(rlp_node);
-                if !bytes_eq(digest.as_slice(), expected_node_ref.as_slice()) {
+                if !digest_eq(digest.as_slice(), expected_node_ref.as_slice()) {
                     return Err(Error::NodeRefMismatch);
                 }
                 expected_node_ref


### PR DESCRIPTION
Decoding compares every node's reference against the one its parent stated. `bytes_eq` walks those
byte by byte, which costs about five instructions per byte: two loads, two pointer bumps and a
branch. At 32 bytes that is ~160 instructions per comparison, and the decoder performs one per node.

The comment on `bytes_eq` explains why it was written that way — slice `==` becomes a `memcmp` call
— and that is still true for slices whose length the compiler cannot see. It is not true when the
length is fixed: the guest target enables `+unaligned-scalar-mem`, so a 32-byte comparison compiles
to eight word loads and an XOR chain, 17 straight-line instructions with no call and no loop.

Three of the four call sites compare a full digest, so they go through a `digest_eq` helper that
fixes the length. The fourth compares a reference shorter than 32 bytes and keeps the byte loop,
which is still the cheaper form there. `digest_eq` is correct for any input because slices of
different lengths are never equal, so a reference that is not a full digest is simply inequality.

`execute_metered_insns` 616,699,072 -> 587,583,276, **-4.721%** (block 24001988, execute-metered).
Rows -4.577%, main cells -1.601%, interaction cells -2.883%, metered memory -0.836%.

The new test covers the direction that matters for soundness: a corrupted digest must be rejected,
including when only its last byte differs, which is what a comparison that stopped short would miss.

The length is fixed here because `NodeRef::Digest` is documented as always 32 bytes, but the variant
holds a `&[u8]` and the invariant is only enforced by a `debug_assert` that release builds drop.
Changing it to `&[u8; 32]` would make this helper unnecessary and enforce the invariant in the type;
left as a follow-up so this change stays measurable on its own.