### PR TITLE
perf(mpt): copy digest references with a fixed length

### DIFF
--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -174,6 +174,21 @@ fn digest_eq(a: &[u8], b: &[u8]) -> bool {
     }
 }
 
+/// Appends a 32-byte node reference to `out`.
+///
+/// Fixing the length keeps the copy inline as whole-word moves. Handing the buffer a slice whose
+/// length the compiler cannot see turns the copy into a `memcpy` call, and at this size the call
+/// costs more than the bytes it moves — encoding node references is the decoder's busiest copy.
+#[inline(always)]
+fn put_digest<B: alloy_rlp::BufMut>(digest: &[u8], out: &mut B) {
+    match <&[u8; DIGEST_LEN]>::try_from(digest) {
+        Ok(digest) => out.put_slice(digest),
+        // A digest reference always holds `DIGEST_LEN` bytes, so this arm exists only to keep the
+        // function total without a conversion that could panic.
+        Err(_) => out.put_slice(digest),
+    }
+}
+
 /// Converts a node id to a branch child slot id.
 /// The only zero id is the null-node sentinel ([`NULL_NODE_ID`]), which is never stored as a
 /// branch child.
@@ -543,7 +558,7 @@ impl<'a> Mpt<'a> {
             // if the reference is a digest, RLP-encode it with its fixed known length
             NodeRef::Digest(digest) => {
                 out.put_u8(alloy_rlp::EMPTY_STRING_CODE + 32);
-                out.put_slice(digest);
+                put_digest(digest, out);
             }
         }
     }


### PR DESCRIPTION
Same defect as the parent PR, on the copy side instead of the compare side, at the busiest copy in
the decoder.

`reference_encode` appends a node reference to the output buffer. For a digest it calls
`put_slice(digest)`, and because `NodeRef::Digest` holds a `&[u8]`, the length is opaque by the time
it reaches the buffer — so a 32-byte copy becomes a `memcpy` call, whose dispatch costs more than the
bytes it moves. In the guest circuit profile, `reference_encode` is the single largest caller of
`memcpy`, at 2.52% of all instructions.

With the length fixed the same copy compiles to four word loads and four word stores inline:

```
copy_from_slice from &[u8]      -> tail memcpy
copy_from_slice from &[u8; 32]  -> 4x ld, 4x sd, ret
```

`execute_metered_insns` 561,010,520 -> 546,501,272, **-2.586%** on top of the parent PR and the
Int256 change (block 24001988, execute-metered). Rows -2.193%, interaction cells -1.914%,
main cells -1.043%, metered memory -0.797%. Segments 60 -> 59.

Worth noting what is *not* affected: `bump.alloc_slice_copy(&digest)` in `calc_reference` and
`decode_trie` is already fine, because there the source is a `[u8; 32]` local and the inlined
`copy_from_slice` sees the constant length. It is specifically the enum variant erasing the length
that defeats the optimizer, which is the argument for giving `NodeRef::Digest` an array type and
deleting both this helper and the parent PR's.