### PR TITLE
perf: prove U256 multiply, shifts and compare with Int256 instructions

### DIFF
--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2502,6 +2502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-bigint-guest"
+version = "2.0.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0#1417e1f11c5578a2fa364e8553f3923ee498fbf8"
+dependencies = [
+ "openvm-platform",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
 name = "openvm-chainspec"
 version = "0.4.0"
 dependencies = [
@@ -2754,6 +2763,7 @@ version = "0.4.0"
 dependencies = [
  "openvm",
  "openvm-algebra-guest",
+ "openvm-bigint-guest",
  "openvm-ecc-guest",
  "openvm-stateless-executor",
 ]
@@ -3823,8 +3833,7 @@ dependencies = [
 [[package]]
 name = "ruint"
 version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+source = "git+https://github.com/Qumeric/uint?rev=cf03e356e38133ad27ee72644e0c4ef7c8e6433e#cf03e356e38133ad27ee72644e0c4ef7c8e6433e"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3852,8 +3861,7 @@ dependencies = [
 [[package]]
 name = "ruint-macro"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+source = "git+https://github.com/Qumeric/uint?rev=cf03e356e38133ad27ee72644e0c4ef7c8e6433e#cf03e356e38133ad27ee72644e0c4ef7c8e6433e"
 
 [[package]]
 name = "rustc-hash"

--- a/bin/stateless-guest/Cargo.toml
+++ b/bin/stateless-guest/Cargo.toml
@@ -13,6 +13,9 @@ openvm-stateless-executor = { path = "../../crates/stateless-executor", default-
 openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", default-features = false, features = ["getrandom-unsupported"] }
 openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", optional = true }
 openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", optional = true }
+# Defines the 256-bit instruction shims that the patched `ruint` below calls. Nothing here
+# references it directly; it is linked in to provide those symbols.
+openvm-bigint-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.1.0", features = ["export-intrinsics"] }
 
 # Enable std feature for host builds (provides critical-section implementation)
 [target.'cfg(not(any(target_os = "none", target_os = "openvm")))'.dependencies]
@@ -20,6 +23,12 @@ openvm-stateless-executor = { path = "../../crates/stateless-executor", default-
 
 [package.metadata.cargo-machete]
 ignored = ["openvm-algebra-guest", "openvm-ecc-guest"]
+
+# `ruint`'s 256-bit multiply, shifts and comparison each become a single OpenVM instruction
+# instead of a limb loop. Only this workspace is patched, because only the guest has the
+# instructions; host builds keep the released crate.
+[patch.crates-io]
+ruint = { git = "https://github.com/Qumeric/uint", rev = "cf03e356e38133ad27ee72644e0c4ef7c8e6433e" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/bin/stateless-guest/src/main.rs
+++ b/bin/stateless-guest/src/main.rs
@@ -5,6 +5,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use openvm::io::{read, reveal_bytes32};
+// Linked for the 256-bit instruction shims it exports, which `ruint` calls. Without a reference
+// the rlib is dropped before those symbols reach the link.
+use openvm_bigint_guest as _;
 use openvm_stateless_executor::{io::StatelessExecutorInput, ChainVariant, StatelessExecutor};
 
 openvm::entry!(main);


### PR DESCRIPTION
OpenVM proves a 256-bit arithmetic operation in a single instruction, and the bigint extension is
already enabled in `openvm.toml` — but nothing was reaching those instructions, because `ruint` does
the arithmetic in software limb loops. This patches the guest's `ruint` to dispatch to them.

## Benchmark results

Both blocks measured against `develop-v2.1.0` at the same commit, execute-metered.

| metric | block 24001988 | block 24002549 |
| --- | ---: | ---: |
| `execute_metered_insns` | 588,618,511 → 562,861,248 (**−4.376%**) | 527,179,427 → 508,428,606 (**−3.557%**) |
| `metered_rows_unpadded` | −4.993% | −3.868% |
| `metered_main_cells_unpadded` | −2.158% | −1.829% |
| `metered_interaction_cells_unpadded` | −3.749% | −3.033% |
| `metered_memory_unpadded_bytes` | −2.867% | −2.492% |
| app segments | 65 → 60 (**−5**) | 59 → 56 (**−3**) |

Runs: block 24001988 [baseline](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031) / [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342069436); block 24002549 [baseline](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342761467) / [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342765751).

Three things worth knowing about the shape of it.

**Not every operation is worth dispatching.** The instructions address memory while `ruint`'s methods
take operands by value, so LLVM has to spill both operands and the result to stack slots the
instruction can point at — about twenty loads and stores it cannot elide, because the inline `asm!`
may read any memory. Measured per operation on riscv64, in the shape revm calls them:

| op | portable | native |
|---|---:|---:|
| `arithmetic_shr` | 164 | 48 |
| `wrapping_shl` | 102 | 40 |
| `wrapping_shr` | 94 | 40 |
| `wrapping_mul` | 65 | 36 |
| `cmp` / `lt` | 37 / 32 | 1 / 8 |
| `wrapping_add` | 27 | **36** |
| `wrapping_sub` | 27 | **36** |

So multiply, the shifts and comparison are dispatched; addition, subtraction and the bitwise
operations deliberately are not — a four-limb carry chain is cheaper than the staging. Comparison
avoids the staging entirely because its operands arrive as references.

**The shifts dispatch from the `Shl`/`Shr` operator impls, not the inherent methods.** `extern "C"`
cannot be called from a `const fn`, and `nybbles` builds lookup tables in `static`s with
`wrapping_shl`, so making that non-const breaks a downstream crate. Trait methods are never const,
and revm's handlers use the operators, so this keeps the win with no `const` fallout.

**It requires `openvm-bigint-guest` linked for its symbols.** Nothing references it in source, so it
needs `use openvm_bigint_guest as _;` or the rlib is dropped before its `#[no_mangle]` exports reach
the link — the same idiom `stateless-executor` already uses for `openvm-guest-mem`.

Correctness: 2.8M differential cases against stock `ruint`, with the instruction shims mocked from
the reference implementation the circuit itself is checked against, so a disagreement would be a
disagreement with the circuit. That caught one real trap — the shift instructions read only the low
byte of the shift amount, so amounts >= 256 wrap instead of clearing, and the wrappers resolve that
themselves.

**Open question before this leaves draft.** It depends on a `ruint` fork
(`Qumeric/uint`, branch `perf/openvm-int256`), patched into this workspace only. `wrapping_mul` and
`arithmetic_shr` have to drop `const` there, which is a breaking change for other `ruint` users, so
that part is not upstreamable as written. Upstream is already unifying `const_*` helpers with runtime
twins (alloy-rs/ruint#615), which is the shape an upstreamable version would take — but until then
this is a fork we carry. That trade is the only thing blocking this PR: the measurement is the
largest in the current queue, and the segment reduction is the largest of any change in flight.
