### PR TITLE
perf: cache repeated storage trie lookups

### DIFF
--- a/crates/stateless-executor/src/io.rs
+++ b/crates/stateless-executor/src/io.rs
@@ -1,5 +1,5 @@
 use alloc::{format, string::ToString, vec::Vec};
-use core::iter::once;
+use core::{cell::Cell, iter::once};
 
 use crate::error::StatelessExecutorError;
 use alloy_consensus::Header;
@@ -275,7 +275,7 @@ pub trait WitnessInput<'a> {
             block_hashes.insert(parent_header.number, child_header.parent_hash);
         }
 
-        Ok(WitnessDb { inner: state, block_hashes, bytecode_by_hash })
+        Ok(WitnessDb::new(state, block_hashes, bytecode_by_hash))
     }
 }
 
@@ -287,6 +287,12 @@ pub struct WitnessDb<'a, 'b> {
     inner: &'b EthereumState<'a>,
     block_hashes: HashMap<u64, B256>,
     bytecode_by_hash: HashMap<B256, &'b Bytecode>,
+    /// Most recently hashed address. Account and storage lookups tend to arrive in runs for the
+    /// same account, so a single entry eliminates repeated address keccaks.
+    hashed_address_cache: Cell<Option<(Address, B256)>>,
+    /// Most recently accessed storage trie. Distinct slot reads for one account can reuse both the
+    /// address hash and the storage-tries hash table lookup.
+    storage_trie_cache: Cell<Option<(Address, &'b Mpt<'a>)>>,
 }
 
 impl<'a, 'b> WitnessDb<'a, 'b> {
@@ -295,7 +301,40 @@ impl<'a, 'b> WitnessDb<'a, 'b> {
         block_hashes: HashMap<u64, B256>,
         bytecode_by_hash: HashMap<B256, &'b Bytecode>,
     ) -> Self {
-        Self { inner, block_hashes, bytecode_by_hash }
+        Self {
+            inner,
+            block_hashes,
+            bytecode_by_hash,
+            hashed_address_cache: Cell::new(None),
+            storage_trie_cache: Cell::new(None),
+        }
+    }
+
+    #[inline]
+    fn hashed_address(&self, address: Address) -> B256 {
+        if let Some((cached_address, hashed_address)) = self.hashed_address_cache.get() {
+            if cached_address == address {
+                return hashed_address;
+            }
+        }
+
+        let hashed_address = keccak256(address);
+        self.hashed_address_cache.set(Some((address, hashed_address)));
+        hashed_address
+    }
+
+    #[inline]
+    fn storage_trie(&self, address: Address) -> Option<&'b Mpt<'a>> {
+        if let Some((cached_address, storage_trie)) = self.storage_trie_cache.get() {
+            if cached_address == address {
+                return Some(storage_trie);
+            }
+        }
+
+        let inner: &'b EthereumState<'a> = self.inner;
+        let storage_trie = inner.storage_tries.get(&self.hashed_address(address))?;
+        self.storage_trie_cache.set(Some((address, storage_trie)));
+        Some(storage_trie)
     }
 }
 
@@ -312,7 +351,7 @@ impl DatabaseRef for WitnessDb<'_, '_> {
 
     /// Get basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let hashed_address = keccak256(address);
+        let hashed_address = self.hashed_address(address);
 
         let account_in_trie = self
             .inner
@@ -343,9 +382,7 @@ impl DatabaseRef for WitnessDb<'_, '_> {
     ///
     /// Returns `U256::ZERO` if the slot is not found in the trie.
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let hashed_address = keccak256(address);
-
-        let storage_trie = self.inner.storage_tries.get(&hashed_address).ok_or_else(|| {
+        let storage_trie = self.storage_trie(address).ok_or_else(|| {
             ProviderError::TrieWitnessError(format!("storage trie for {address} not found"))
         })?;
 

--- a/crates/stateless-executor/src/io.rs
+++ b/crates/stateless-executor/src/io.rs
@@ -7,7 +7,7 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
 use bumpalo::Bump;
 use itertools::Itertools;
-use openvm_mpt::{EthereumState, EthereumStateBytes, Mpt};
+use openvm_mpt::{Error as MptError, EthereumState, EthereumStateBytes, Mpt};
 use reth_ethereum_primitives::Block;
 use reth_evm::execute::ProviderError;
 use revm::{
@@ -284,30 +284,25 @@ pub trait WitnessInput<'a> {
 /// is the lifetime of the borrows of the state and bytecodes.
 #[derive(Debug)]
 pub struct WitnessDb<'a, 'b> {
-    inner: &'b EthereumState<'a>,
+    trie_lookups: CachedTrieLookups<'a, 'b>,
     block_hashes: HashMap<u64, B256>,
     bytecode_by_hash: HashMap<B256, &'b Bytecode>,
-    /// Most recently hashed address. Account and storage lookups tend to arrive in runs for the
-    /// same account, so a single entry eliminates repeated address keccaks.
+}
+
+/// Cached access to the account and storage tries in an [`EthereumState`].
+///
+/// Account and storage accesses tend to arrive in runs for the same account, so one entry per
+/// lookup captures that locality without allocating general-purpose caches.
+#[derive(Debug)]
+struct CachedTrieLookups<'a, 'b> {
+    state: &'b EthereumState<'a>,
     hashed_address_cache: Cell<Option<(Address, B256)>>,
-    /// Most recently accessed storage trie. Distinct slot reads for one account can reuse both the
-    /// address hash and the storage-tries hash table lookup.
     storage_trie_cache: Cell<Option<(Address, &'b Mpt<'a>)>>,
 }
 
-impl<'a, 'b> WitnessDb<'a, 'b> {
-    pub fn new(
-        inner: &'b EthereumState<'a>,
-        block_hashes: HashMap<u64, B256>,
-        bytecode_by_hash: HashMap<B256, &'b Bytecode>,
-    ) -> Self {
-        Self {
-            inner,
-            block_hashes,
-            bytecode_by_hash,
-            hashed_address_cache: Cell::new(None),
-            storage_trie_cache: Cell::new(None),
-        }
+impl<'a, 'b> CachedTrieLookups<'a, 'b> {
+    fn new(state: &'b EthereumState<'a>) -> Self {
+        Self { state, hashed_address_cache: Cell::new(None), storage_trie_cache: Cell::new(None) }
     }
 
     #[inline]
@@ -323,6 +318,11 @@ impl<'a, 'b> WitnessDb<'a, 'b> {
         hashed_address
     }
 
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, MptError> {
+        let hashed_address = self.hashed_address(address);
+        self.state.state_trie.get_rlp::<TrieAccount>(hashed_address.as_slice())
+    }
+
     #[inline]
     fn storage_trie(&self, address: Address) -> Option<&'b Mpt<'a>> {
         if let Some((cached_address, storage_trie)) = self.storage_trie_cache.get() {
@@ -331,16 +331,25 @@ impl<'a, 'b> WitnessDb<'a, 'b> {
             }
         }
 
-        let inner: &'b EthereumState<'a> = self.inner;
-        let storage_trie = inner.storage_tries.get(&self.hashed_address(address))?;
+        let storage_trie = self.state.storage_tries.get(&self.hashed_address(address))?;
         self.storage_trie_cache.set(Some((address, storage_trie)));
         Some(storage_trie)
     }
 }
 
-fn trie_error_to_provider_error(trie_error: openvm_mpt::Error) -> ProviderError {
+impl<'a, 'b> WitnessDb<'a, 'b> {
+    pub fn new(
+        state: &'b EthereumState<'a>,
+        block_hashes: HashMap<u64, B256>,
+        bytecode_by_hash: HashMap<B256, &'b Bytecode>,
+    ) -> Self {
+        Self { trie_lookups: CachedTrieLookups::new(state), block_hashes, bytecode_by_hash }
+    }
+}
+
+fn trie_error_to_provider_error(trie_error: MptError) -> ProviderError {
     match trie_error {
-        openvm_mpt::Error::RlpError(error) => ProviderError::Rlp(error),
+        MptError::RlpError(error) => ProviderError::Rlp(error),
         _ => ProviderError::TrieWitnessError(trie_error.to_string()),
     }
 }
@@ -351,13 +360,8 @@ impl DatabaseRef for WitnessDb<'_, '_> {
 
     /// Get basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let hashed_address = self.hashed_address(address);
-
-        let account_in_trie = self
-            .inner
-            .state_trie
-            .get_rlp::<TrieAccount>(hashed_address.as_slice())
-            .map_err(trie_error_to_provider_error)?;
+        let account_in_trie =
+            self.trie_lookups.account(address).map_err(trie_error_to_provider_error)?;
 
         let account = account_in_trie.map(|account_in_trie| AccountInfo {
             balance: account_in_trie.balance,
@@ -382,7 +386,7 @@ impl DatabaseRef for WitnessDb<'_, '_> {
     ///
     /// Returns `U256::ZERO` if the slot is not found in the trie.
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let storage_trie = self.storage_trie(address).ok_or_else(|| {
+        let storage_trie = self.trie_lookups.storage_trie(address).ok_or_else(|| {
             ProviderError::TrieWitnessError(format!("storage trie for {address} not found"))
         })?;
 


### PR DESCRIPTION
Add one-entry caches for address hashes and storage-trie references in `WitnessDb`. REVM storage accesses commonly arrive in runs for the same account, so this avoids repeated address Keccak operations and storage-trie hash-table lookups without adding a general-purpose cache.

`WitnessDb` borrows the backing Ethereum state immutably, so cached trie references cannot become stale during execution.

## Benchmark results

Block 24001988, execute-metered, [`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342071938):

| metric | `develop-v2.1.0` | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 588,618,511 | 585,948,254 | **−2,670,257 (−0.454%)** |
| `metered_rows_unpadded` | 844,070,559 | 838,480,858 | −5,589,701 (−0.662%) |
| `metered_main_cells_unpadded` | 43,260,383,096 | 42,788,778,698 | **−471,604,398 (−1.090%)** |
| `metered_interaction_cells_unpadded` | 13,194,454,796 | 13,132,564,727 | −61,890,069 (−0.469%) |
| `metered_memory_unpadded_bytes` | 713,961,114,662 | 711,203,678,744 | −2,757,435,918 (−0.386%) |
| app segments | 65 | 64 | **−1** |

Cells fall about twice as far as instructions, and the block crosses a segment boundary, because the work being skipped is trie resolution — memory traffic rather than arithmetic.
