### PR TITLE
perf(mpt): specialize the RLP shapes the witness contains, behind an rlp module

### DIFF
--- a/crates/mpt/src/hp.rs
+++ b/crates/mpt/src/hp.rs
@@ -1,5 +1,5 @@
 //! Hex-prefix (HP) helpers and nibble utilities for MPT paths.
-use core::{cmp, iter};
+use core::cmp;
 use smallvec::SmallVec;
 
 /// Compact vector for nibble sequences used in key traversal.
@@ -7,30 +7,77 @@ pub(crate) type Nibbles = SmallVec<[u8; 64]>;
 
 // Hex-prefix (HP) encoding flags for MPT paths
 pub(crate) const HP_FLAG_ODD: u8 = 0x10; // path has odd number of nibbles; low nibble of first byte is data
-#[allow(dead_code)]
 pub(crate) const HP_FLAG_LEAF: u8 = 0x20; // node is a leaf (vs extension)
 
-/// Returns the length of the common prefix (in nibbles) between two nibble slices.
+/// A cursor over the nibbles of a lookup key. Trie traversal tracks a nibble offset into the raw
+/// key bytes and computes nibbles by shift/mask on demand, instead of materializing the nibble
+/// array up front.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct KeyNibbles<'k> {
+    key: &'k [u8],
+    /// Position of the cursor, in nibbles from the start of `key`.
+    offset: usize,
+}
+
+impl<'k> KeyNibbles<'k> {
+    #[inline(always)]
+    pub(crate) fn new(key: &'k [u8]) -> Self {
+        Self { key, offset: 0 }
+    }
+
+    /// Number of nibbles remaining after the cursor. Since the key is a whole number of bytes,
+    /// this always has the same parity as `offset`.
+    #[inline(always)]
+    pub(crate) fn remaining(&self) -> usize {
+        2 * self.key.len() - self.offset
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    /// The `i`-th nibble after the cursor.
+    #[inline(always)]
+    pub(crate) fn nib(&self, i: usize) -> u8 {
+        let j = self.offset + i;
+        let byte = self.key[j / 2];
+        if j % 2 == 0 {
+            byte >> 4
+        } else {
+            byte & 0x0f
+        }
+    }
+
+    /// Splits off the first nibble, like `slice::split_first`.
+    #[inline(always)]
+    pub(crate) fn split_first(&self) -> Option<(u8, Self)> {
+        if self.is_empty() {
+            None
+        } else {
+            Some((self.nib(0), self.advanced(1)))
+        }
+    }
+
+    /// The cursor advanced by `n` nibbles.
+    #[inline(always)]
+    pub(crate) fn advanced(&self, n: usize) -> Self {
+        debug_assert!(n <= self.remaining());
+        Self { key: self.key, offset: self.offset + n }
+    }
+}
+
+/// Returns the length of the common prefix (in nibbles) between a nibble slice and the key
+/// nibbles at the cursor.
 #[inline]
-pub(crate) fn lcp(a: &[u8], b: &[u8]) -> usize {
-    for (i, (a, b)) in iter::zip(a, b).enumerate() {
-        if a != b {
+pub(crate) fn lcp_key(nibs: &[u8], key: KeyNibbles<'_>) -> usize {
+    let max = cmp::min(nibs.len(), key.remaining());
+    for (i, &nib) in nibs[..max].iter().enumerate() {
+        if nib != key.nib(i) {
             return i;
         }
     }
-    cmp::min(a.len(), b.len())
-}
-
-/// Converts a byte slice into a vector of nibbles.
-/// Uses `SmallVec` to avoid heap allocation for typical key sizes (≤32 bytes = 64 nibbles).
-#[inline]
-pub(crate) fn to_nibs(slice: &[u8]) -> Nibbles {
-    let mut result = SmallVec::with_capacity(2 * slice.len());
-    for byte in slice {
-        result.push(byte >> 4);
-        result.push(byte & 0x0f);
-    }
-    result
+    max
 }
 
 /// Decodes a compact hex-prefix-encoded path (as used in MPT leaf/extension nodes)
@@ -72,100 +119,99 @@ pub(crate) fn encoded_path_nibble_count(encoded_path: &[u8]) -> usize {
     2 * (encoded_path.len() - 1) + if is_odd { 1 } else { 0 }
 }
 
-/// Compares a compact hex-prefix path with a nibble slice for equality without allocating.
+/// Compares a compact hex-prefix path with the key nibbles at the cursor for equality, without
+/// allocating.
 #[inline]
-pub(crate) fn encoded_path_eq_nibs(encoded_path: &[u8], nibs: &[u8]) -> bool {
+pub(crate) fn encoded_path_eq_key(encoded_path: &[u8], key: KeyNibbles<'_>) -> bool {
     let nib_count = encoded_path_nibble_count(encoded_path);
-    if nib_count != nibs.len() {
+    if nib_count != key.remaining() {
         return false;
     }
+    encoded_path_matches_key(encoded_path, nib_count, key)
+}
+
+/// If `encoded_path` is a prefix of the key nibbles at the cursor, returns the cursor advanced
+/// past it.
+#[inline]
+pub(crate) fn encoded_path_strip_prefix_key<'k>(
+    encoded_path: &[u8],
+    key: KeyNibbles<'k>,
+) -> Option<KeyNibbles<'k>> {
+    let nib_count = encoded_path_nibble_count(encoded_path);
+    if nib_count > key.remaining() {
+        return None;
+    }
+    encoded_path_matches_key(encoded_path, nib_count, key).then(|| key.advanced(nib_count))
+}
+
+/// Whether the first `nib_count` key nibbles at the cursor equal the path's nibbles.
+///
+/// After the path's optional odd leading nibble its data is whole bytes, so a cursor that is
+/// byte-aligned there can be compared as a whole byte slice. That is always the case when the path
+/// spans the entire remaining key: a cursor's parity matches its remaining length's, and a path's
+/// parity matches its nibble count's, so equal lengths force equal parity. Only a path shorter
+/// than the remaining key — an extension — can land misaligned and need the nibble-wise loop.
+#[inline]
+fn encoded_path_matches_key(encoded_path: &[u8], nib_count: usize, key: KeyNibbles<'_>) -> bool {
+    debug_assert!(nib_count <= key.remaining(), "caller must bound the path by the key");
     if nib_count == 0 {
         return true;
     }
 
     let first = encoded_path[0];
     let is_odd = (first & HP_FLAG_ODD) != 0;
-    let mut i = 0usize; // index in nibs
-    let mut j = 1usize; // index in encoded_path bytes
-
-    if is_odd {
-        if nibs[i] != (first & 0x0f) {
-            return false;
-        }
-        i += 1;
+    let start = usize::from(is_odd);
+    if is_odd && key.nib(0) != (first & 0x0f) {
+        return false;
     }
 
-    while i + 1 < nibs.len() {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return false;
-        }
-        if nibs[i + 1] != (b & 0x0f) {
-            return false;
-        }
-        i += 2;
-        j += 1;
+    let path_data = &encoded_path[1..];
+    if (key.offset + start) % 2 == 0 {
+        let key_start = (key.offset + start) / 2;
+        return key.key[key_start..key_start + path_data.len()] == *path_data;
     }
 
-    if i < nibs.len() {
-        // one last high nibble remains
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
+    // The path's byte boundaries are misaligned with the key's (possible for extension paths);
+    // compare nibble by nibble.
+    for (j, &byte) in path_data.iter().enumerate() {
+        let i = start + 2 * j;
+        if key.nib(i) != (byte >> 4) || key.nib(i + 1) != (byte & 0x0f) {
             return false;
         }
     }
     true
 }
 
-/// If `encoded_path` is a prefix of `nibs`, returns the tail `&nibs[matched_len..]`.
+/// Encodes the key nibbles remaining after the cursor into hex-prefix format in the bump arena.
+///
+/// The cursor's offset and its remaining length always share a parity, so after the encoding's
+/// optional odd leading nibble the cursor sits on a byte boundary and the rest of the path is a
+/// direct copy of the key's remaining bytes. See [`to_encoded_path_with_bump`] for paths rebuilt
+/// from a stored node's nibbles, which have no such alignment to exploit.
 #[inline]
-pub(crate) fn encoded_path_strip_prefix<'a>(
-    encoded_path: &[u8],
-    nibs: &'a [u8],
-) -> Option<&'a [u8]> {
-    let nib_count = encoded_path_nibble_count(encoded_path);
-    if nib_count > nibs.len() {
-        return None;
-    }
-    if nib_count == 0 {
-        return Some(nibs);
-    }
+pub(crate) fn encoded_path_from_key<'a>(
+    bump: &'a bumpalo::Bump,
+    key: KeyNibbles<'_>,
+    is_leaf: bool,
+) -> &'a [u8] {
+    let remaining = key.remaining();
+    let is_odd = !remaining.is_multiple_of(2);
+    let start = usize::from(is_odd);
 
-    let first = encoded_path[0];
-    let is_odd = (first & HP_FLAG_ODD) != 0;
-    let mut i = 0usize; // index in nibs
-    let mut j = 1usize; // index in encoded_path bytes
-
+    let mut prefix = if is_leaf { HP_FLAG_LEAF } else { 0x00 };
     if is_odd {
-        if nibs[i] != (first & 0x0f) {
-            return None;
-        }
-        i += 1;
+        prefix |= HP_FLAG_ODD | key.nib(0);
     }
 
-    while i + 1 < nib_count {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return None;
-        }
-        if nibs[i + 1] != (b & 0x0f) {
-            return None;
-        }
-        i += 2;
-        j += 1;
-    }
-
-    if i < nib_count {
-        let b = encoded_path[j];
-        if nibs[i] != (b >> 4) {
-            return None;
-        }
-        i += 1;
-    }
-    Some(&nibs[i..])
+    let encoded = bump.alloc_slice_fill_copy(1 + remaining / 2, 0);
+    encoded[0] = prefix;
+    encoded[1..].copy_from_slice(&key.key[(key.offset + start) / 2..]);
+    encoded
 }
 
-/// Encodes nibbles into the standard hex-prefix format directly into the bump arena.
+/// Encodes a materialized nibble sequence into the standard hex-prefix format directly into the
+/// bump arena. This is the form used for paths rebuilt from a stored node's nibbles; paths built
+/// from a lookup key go through [`encoded_path_from_key`], which needs no nibble array.
 #[inline]
 pub(crate) fn to_encoded_path_with_bump<'a>(
     bump: &'a bumpalo::Bump,
@@ -176,9 +222,9 @@ pub(crate) fn to_encoded_path_with_bump<'a>(
     let encoded_len = 1 + (nibs.len() / 2);
     let mut encoded = bumpalo::collections::Vec::with_capacity_in(encoded_len, bump);
 
-    let mut prefix = if is_leaf { 0x20 } else { 0x00 };
+    let mut prefix = if is_leaf { HP_FLAG_LEAF } else { 0x00 };
     if is_odd {
-        prefix |= 0x10;
+        prefix |= HP_FLAG_ODD;
         encoded.push(prefix | nibs[0]);
         for i in (1..nibs.len()).step_by(2) {
             encoded.push((nibs[i] << 4) | nibs[i + 1]);
@@ -191,32 +237,6 @@ pub(crate) fn to_encoded_path_with_bump<'a>(
     }
 
     encoded.into_bump_slice()
-}
-
-/// Encodes nibbles into the standard hex-prefix format.
-#[cfg(feature = "host")]
-#[allow(dead_code)]
-#[inline]
-pub(crate) fn to_encoded_path(nibs: &[u8], is_leaf: bool) -> Vec<u8> {
-    let is_odd = !nibs.len().is_multiple_of(2);
-    let encoded_len = 1 + (nibs.len() / 2);
-    let mut encoded = Vec::with_capacity(encoded_len);
-
-    let mut prefix = if is_leaf { 0x20 } else { 0x00 };
-    if is_odd {
-        prefix |= 0x10;
-        encoded.push(prefix | nibs[0]);
-        for i in (1..nibs.len()).step_by(2) {
-            encoded.push((nibs[i] << 4) | nibs[i + 1]);
-        }
-    } else {
-        encoded.push(prefix);
-        for i in (0..nibs.len()).step_by(2) {
-            encoded.push((nibs[i] << 4) | nibs[i + 1]);
-        }
-    }
-
-    encoded
 }
 
 #[cfg(test)]
@@ -232,19 +252,95 @@ mod tests {
         assert_eq!(encoded_path_nibble_count(&[0x00, 0xab, 0xcd]), 4);
     }
 
+    /// Collects the nibbles remaining after a cursor, for assertions.
+    fn nibs_of(key: KeyNibbles<'_>) -> Vec<u8> {
+        (0..key.remaining()).map(|i| key.nib(i)).collect()
+    }
+
+    #[test]
+    fn test_key_nibbles_cursor() {
+        let key = KeyNibbles::new(&[0x12, 0x34]);
+        assert_eq!(key.remaining(), 4);
+        assert_eq!(nibs_of(key), vec![1, 2, 3, 4]);
+
+        let (first, rest) = key.split_first().unwrap();
+        assert_eq!(first, 1);
+        assert_eq!(nibs_of(rest), vec![2, 3, 4]);
+
+        let empty = key.advanced(4);
+        assert!(empty.is_empty());
+        assert!(empty.split_first().is_none());
+    }
+
+    /// The byte-slice fast paths in `encoded_path_matches_key` and `encoded_path_from_key` rely on
+    /// this: a cursor into a whole number of bytes sits at an odd offset only when an odd number
+    /// of nibbles remains, so skipping a path's odd leading nibble always lands on a byte boundary.
+    #[test]
+    fn test_cursor_offset_and_remaining_share_parity() {
+        for key_len in 0..4usize {
+            let bytes = vec![0xab; key_len];
+            let key = KeyNibbles::new(&bytes);
+            for offset in 0..=2 * key_len {
+                assert_eq!(offset % 2, key.advanced(offset).remaining() % 2);
+            }
+        }
+    }
+
     #[test]
     fn test_eq_and_strip_prefix() {
         // path [1, 2, 3] as HP: ODD + EXT, first byte 0x10 | 0x1, then 0x23
         let path = [HP_FLAG_ODD | 0x01, 0x23];
-        let key = [1, 2, 3];
-        assert!(encoded_path_eq_nibs(&path, &key));
-        assert_eq!(encoded_path_strip_prefix(&path, &key), Some(&[][..]));
+        // key nibbles [1, 2, 3]: cursor at offset 1 into bytes [0x01, 0x23]
+        let key = KeyNibbles::new(&[0x01, 0x23]).advanced(1);
+        assert!(encoded_path_eq_key(&path, key));
+        assert!(encoded_path_strip_prefix_key(&path, key).unwrap().is_empty());
 
-        let key_longer = [1, 2, 3, 4, 5];
-        assert_eq!(encoded_path_strip_prefix(&path, &key_longer), Some(&key_longer[3..]));
+        // key nibbles [1, 2, 3, 4, 5]: cursor at offset 1 into bytes [0x01, 0x23, 0x45]
+        let key_longer = KeyNibbles::new(&[0x01, 0x23, 0x45]).advanced(1);
+        assert!(!encoded_path_eq_key(&path, key_longer));
+        let tail = encoded_path_strip_prefix_key(&path, key_longer).unwrap();
+        assert_eq!(nibs_of(tail), vec![4, 5]);
 
-        let key_mismatch = [1, 2, 4];
-        assert!(encoded_path_strip_prefix(&path, &key_mismatch).is_none());
+        // key nibbles [1, 2, 4]
+        let key_mismatch = KeyNibbles::new(&[0x01, 0x24]).advanced(1);
+        assert!(encoded_path_strip_prefix_key(&path, key_mismatch).is_none());
+
+        // even-length path [2, 3] against a misaligned (odd-offset) cursor
+        let even_path = [0x00, 0x23];
+        let key_misaligned = KeyNibbles::new(&[0x02, 0x34]).advanced(1);
+        let tail = encoded_path_strip_prefix_key(&even_path, key_misaligned).unwrap();
+        assert_eq!(nibs_of(tail), vec![4]);
+        assert!(encoded_path_strip_prefix_key(
+            &even_path,
+            KeyNibbles::new(&[0x02, 0x44]).advanced(1)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_encoded_path_from_key() {
+        let bump = bumpalo::Bump::new();
+
+        let key = KeyNibbles::new(&[0xab, 0xcd]);
+        // leaf with an even remainder
+        assert_eq!(encoded_path_from_key(&bump, key, true), &[0x20, 0xab, 0xcd]);
+        // extension with an odd remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(1), false), &[0x1b, 0xcd]);
+        // leaf with an odd remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(3), true), &[0x3d]);
+        // empty remainder
+        assert_eq!(encoded_path_from_key(&bump, key.advanced(4), true), &[0x20]);
+    }
+
+    #[test]
+    fn test_lcp_key() {
+        let key = KeyNibbles::new(&[0xab, 0xcd]);
+        assert_eq!(lcp_key(&[], key), 0);
+        assert_eq!(lcp_key(&[0xa], key), 1);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xd], key), 2);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xc, 0xd], key), 4);
+        assert_eq!(lcp_key(&[0xa, 0xb, 0xc, 0xd, 0xe], key), 4);
+        assert_eq!(lcp_key(&[0xb, 0xc], key.advanced(1)), 2);
     }
 
     #[test]
@@ -263,22 +359,5 @@ mod tests {
         // leaf node with an odd path length
         let nibbles = vec![0x0a, 0x0b, 0x0c];
         assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, true), vec![0x3a, 0xbc]);
-    }
-
-    #[test]
-    fn test_lcp() {
-        let cases = [
-            (vec![], vec![], 0),
-            (vec![0xa], vec![0xa], 1),
-            (vec![0xa, 0xb], vec![0xa, 0xc], 1),
-            (vec![0xa, 0xb], vec![0xa, 0xb], 2),
-            (vec![0xa, 0xb], vec![0xa, 0xb, 0xc], 2),
-            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc], 3),
-            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc, 0xd], 3),
-            (vec![0xa, 0xb, 0xc, 0xd], vec![0xa, 0xb, 0xc, 0xd], 4),
-        ];
-        for (a, b, cpl) in cases {
-            assert_eq!(lcp(&a, &b), cpl)
-        }
     }
 }

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -11,6 +11,7 @@ pub use state::*;
 mod bump_bufmut;
 mod hp;
 mod node;
+mod rlp;
 
 #[cfg(feature = "host")]
 pub mod resolver;

--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -1,11 +1,16 @@
-use core::cell::Cell;
+use core::{cell::Cell, num::NonZeroU32};
 
 use revm_primitives::hex;
 
 pub(crate) type NodeId = u32;
 
+/// Id of a branch child node. `NonZero` so that a child slot (`Option<BranchChildId>`) fits in
+/// 4 bytes — `Option<u32>` has no niche and takes 8. Node id 0 is the null-node sentinel
+/// (`NULL_NODE_ID`) and is never stored as a branch child.
+pub(crate) type BranchChildId = NonZeroU32;
+
 /// Children slots of a branch node, allocated in the trie's bump arena.
-pub(crate) type BranchChildren<'a> = &'a [Cell<Option<NodeId>>; 16];
+pub(crate) type BranchChildren<'a> = &'a [Cell<Option<BranchChildId>>; 16];
 
 /// Node data for arena-based trie with zero-copy optimization.
 ///

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    node::{NodeData, NodeId},
+    node::{BranchChildId, NodeData, NodeId},
     trie::{NULL_NODE_ID, NULL_NODE_REF_SLICE},
     Error, Mpt,
 };
@@ -77,10 +77,11 @@ impl MptResolver {
                         return Err(Error::ValueInBranch);
                     }
 
-                    let mut childs: [Option<NodeId>; 16] = Default::default();
+                    let mut childs: [Option<BranchChildId>; 16] = Default::default();
                     for (i, mut item) in items.into_iter().take(16).enumerate() {
                         let child_id = self.resolve_internal(&mut item, mpt)?;
-                        childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
+                        // `BranchChildId::new` maps the `NULL_NODE_ID` sentinel (0) to `None`.
+                        childs[i] = BranchChildId::new(child_id);
                     }
                     // The children array is allocated in `mpt`'s own bump, so no copy is needed.
                     let children = mpt.alloc_branch(childs);

--- a/crates/mpt/src/resolver.rs
+++ b/crates/mpt/src/resolver.rs
@@ -1,6 +1,7 @@
 use crate::{
     node::{BranchChildId, NodeData, NodeId},
-    trie::{NULL_NODE_ID, NULL_NODE_REF_SLICE},
+    rlp::NULL_NODE_REF_SLICE,
+    trie::NULL_NODE_ID,
     Error, Mpt,
 };
 use alloy_rlp::PayloadView;

--- a/crates/mpt/src/rlp.rs
+++ b/crates/mpt/src/rlp.rs
@@ -1,0 +1,151 @@
+//! RLP encoding and decoding specialized for the shapes a trie witness actually contains.
+//!
+//! `alloy_rlp` handles every legal RLP encoding, and pays for that generality twice over: its
+//! decoder branches through the full header space on each item, and its encoder writes through
+//! `&mut dyn BufMut`, so every byte costs a virtual call. Trie nodes use a handful of shapes —
+//! 16-child lists, 32-byte digest references, short strings, the empty string — and each is
+//! reachable in a comparison or two. The functions here take those paths directly and fall back
+//! to `alloy_rlp` for anything else, so behaviour is identical and only the common cases get
+//! faster.
+//!
+//! Every specialization is checked against `alloy_rlp` in this module's tests, since agreeing
+//! with the general implementation on all inputs is the whole correctness requirement.
+
+use bytes::Buf;
+
+use crate::Error;
+
+/// The RLP encoding of an empty node reference.
+pub(crate) const NULL_NODE_REF_SLICE: &[u8] = &[alloy_rlp::EMPTY_STRING_CODE];
+
+/// Splits the first `cnt` bytes off `buf`.
+///
+/// # Safety
+///
+/// `buf` must hold at least `cnt` bytes.
+#[inline(always)]
+pub(crate) unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
+    let bytes = &buf[..cnt];
+    buf.advance(cnt);
+    bytes
+}
+
+/// Decodes and advances past one RLP item, returning its full encoding and payload. Common
+/// single-byte headers are handled directly, with the generic decoder as a fallback.
+#[inline(always)]
+pub(crate) fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error> {
+    let item_start = *buf;
+    if item_start.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
+        *buf = &item_start[1..];
+        return Ok((&item_start[..1], &item_start[1..1]));
+    }
+    if item_start.first() == Some(&(alloy_rlp::EMPTY_STRING_CODE + 32)) {
+        let item = item_start.get(..33).ok_or(alloy_rlp::Error::InputTooShort)?;
+        *buf = &item_start[33..];
+        return Ok((item, &item[1..]));
+    }
+    if let Some(code @ 0x81..=0xb7) = item_start.first().copied() {
+        let payload_length = usize::from(code - alloy_rlp::EMPTY_STRING_CODE);
+        let item = item_start.get(..payload_length + 1).ok_or(alloy_rlp::Error::InputTooShort)?;
+        let payload = &item[1..];
+        if payload_length == 1 && payload[0] < alloy_rlp::EMPTY_STRING_CODE {
+            return Err(alloy_rlp::Error::NonCanonicalSingleByte.into());
+        }
+        *buf = &item_start[payload_length + 1..];
+        return Ok((item, payload));
+    }
+
+    let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
+    // SAFETY: the header was decoded, so the item contains its declared payload.
+    let payload = unsafe { advance_unchecked(buf, payload_length) };
+    let item_length = item_start.len() - buf.len();
+    Ok((&item_start[..item_length], payload))
+}
+
+/// Decodes an MPT node header, specializing the canonical list headers used by resolved nodes.
+/// The generic decoder remains the fallback for strings and larger lists.
+#[inline(always)]
+pub(crate) fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
+    let input = *buf;
+    match input.first().copied() {
+        Some(code @ alloy_rlp::EMPTY_LIST_CODE..=0xf7) => {
+            let payload_length = usize::from(code - alloy_rlp::EMPTY_LIST_CODE);
+            if input.len() < payload_length + 1 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[1..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf8) => {
+            let payload_length = usize::from(*input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?);
+            if payload_length < 56 {
+                return Err(alloy_rlp::Error::NonCanonicalSize.into());
+            }
+            if input.len() < payload_length + 2 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[2..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf9) => {
+            let high = *input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?;
+            let low = *input.get(2).ok_or(alloy_rlp::Error::InputTooShort)?;
+            if high == 0 {
+                return Err(alloy_rlp::Error::LeadingZero.into());
+            }
+            let payload_length = (usize::from(high) << 8) | usize::from(low);
+            if input.len() < payload_length + 3 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[3..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        _ => alloy_rlp::Header::decode(buf).map_err(Into::into),
+    }
+}
+
+/// Whether `slice` is the RLP encoding of an empty node reference: a single `EMPTY_STRING_CODE`
+/// byte. Written as an explicit pattern match because comparing against [`NULL_NODE_REF_SLICE`]
+/// with `==` compiles to a `memcmp` call, whose overhead dwarfs this one-byte check — and trie
+/// decoding performs it for every branch child.
+#[inline(always)]
+pub(crate) fn is_null_ref(slice: &[u8]) -> bool {
+    matches!(slice, [byte] if *byte == alloy_rlp::EMPTY_STRING_CODE)
+}
+
+/// Writes an RLP header with the given base code (`EMPTY_LIST_CODE` for lists,
+/// `EMPTY_STRING_CODE` for strings). Emits the same bytes as [`alloy_rlp::Header::encode`], but
+/// is generic over the output buffer: `alloy_rlp` encoding goes through `&mut dyn BufMut`, and
+/// the resulting per-write dynamic dispatch is expensive in the zkVM.
+#[inline]
+pub(crate) fn encode_header<B: alloy_rlp::BufMut>(
+    base_code: u8,
+    payload_length: usize,
+    out: &mut B,
+) {
+    if payload_length < 56 {
+        out.put_u8(base_code + payload_length as u8);
+    } else {
+        let len_be = payload_length.to_be_bytes();
+        let num_len_bytes = alloy_rlp::length_of_length(payload_length) - 1;
+        out.put_u8(base_code + 55 + num_len_bytes as u8);
+        out.put_slice(&len_be[len_be.len() - num_len_bytes..]);
+    }
+}
+
+/// RLP-encodes a byte slice as a string. Emits the same bytes as `Encodable for [u8]`, without
+/// dynamic dispatch (see [`encode_header`]).
+#[inline]
+pub(crate) fn encode_slice<B: alloy_rlp::BufMut>(bytes: &[u8], out: &mut B) {
+    if let [byte] = bytes {
+        if *byte < alloy_rlp::EMPTY_STRING_CODE {
+            out.put_u8(*byte);
+            return;
+        }
+    }
+    encode_header(alloy_rlp::EMPTY_STRING_CODE, bytes.len(), out);
+    out.put_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mpt/src/rlp/tests.rs
+++ b/crates/mpt/src/rlp/tests.rs
@@ -1,0 +1,248 @@
+//! Differential tests: every specialization here must agree with `alloy_rlp`.
+//!
+//! The specializations exist only to reach common encodings in fewer instructions, so the
+//! property that matters is indistinguishability from the general implementation. Each test
+//! sweeps a leading byte across the whole `u8` range — the dimension that selects which
+//! specialized arm runs — against payload lengths straddling the header-form boundaries (1-byte,
+//! 2-byte and 3-byte length prefixes), which covers each arm and its fallback.
+//!
+//! The sweeps also vary the bytes following the lead (see [`Filler`]). For the forms that carry a
+//! multi-byte length those bytes *are* the declared length, so a fixed filler would pin each such
+//! arm to one length value and leave its canonicality rules unexercised.
+//!
+//! Errors are compared as accept-or-reject rather than by variant: the decoder's contract is
+//! that it rejects what `alloy_rlp` rejects, and the specific variant reaching the caller is not
+//! part of it.
+
+use alloc::vec::Vec;
+
+use super::*;
+
+/// Payload lengths that straddle every header form: single byte, `0x81..=0xb7` short string,
+/// `0xb8`/`0xf8` one-byte length, and `0xb9`/`0xf9` two-byte length.
+const LENS: [usize; 14] = [0, 1, 2, 31, 32, 33, 54, 55, 56, 57, 254, 255, 256, 300];
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i as u8).wrapping_mul(31).wrapping_add(7)).collect()
+}
+
+/// Filler bytes to sweep after the leading byte. For the header forms that carry a multi-byte
+/// length, those bytes *are* the declared length, so varying them is what reaches the canonicality
+/// rules: `Zeros` produces a length with a leading zero and a long-form length below 56, `Ones`
+/// produces a maximal one, and `Pattern` covers the mid-range. Holding this constant would leave
+/// each multi-byte-length arm tested at a single declared length.
+#[derive(Copy, Clone, Debug)]
+enum Filler {
+    Pattern,
+    Zeros,
+    Ones,
+}
+
+const FILLERS: [Filler; 3] = [Filler::Pattern, Filler::Zeros, Filler::Ones];
+
+/// Lengths that straddle where a header gains length bytes, plus a few interior values.
+const EXTRAS: [usize; 11] = [0, 1, 2, 3, 32, 33, 55, 56, 57, 258, 300];
+
+/// A leading byte followed by `extra` filler bytes. Most combinations are invalid RLP, which is
+/// the point: the specialized decoder must reject exactly what `alloy_rlp` rejects.
+fn synthetic(lead: u8, extra: usize, filler: Filler) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(extra + 1);
+    buf.push(lead);
+    match filler {
+        Filler::Pattern => buf.extend(payload(extra)),
+        Filler::Zeros => buf.resize(extra + 1, 0x00),
+        Filler::Ones => buf.resize(extra + 1, 0xff),
+    }
+    buf
+}
+
+#[test]
+fn decode_node_header_matches_alloy() {
+    let mut checked = 0u32;
+    for filler in FILLERS {
+        for lead in 0..=u8::MAX {
+            for extra in EXTRAS {
+                let input = synthetic(lead, extra, filler);
+
+                let mut ours = input.as_slice();
+                let got = decode_node_header(&mut ours);
+
+                let mut theirs = input.as_slice();
+                let want = alloy_rlp::Header::decode(&mut theirs);
+
+                match (got, want) {
+                    (Ok(got), Ok(want)) => {
+                        assert_eq!(
+                            got.list, want.list,
+                            "lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                        assert_eq!(
+                            got.payload_length, want.payload_length,
+                            "lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                        assert_eq!(
+                            ours.len(),
+                            theirs.len(),
+                            "advance: lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                    }
+                    (Err(_), Err(_)) => {}
+                    (got, want) => panic!(
+                        "accept/reject disagreement: lead={lead:#04x} extra={extra} {filler:?} \
+                         ours={:?} alloy={:?}",
+                        got.map(|h| (h.list, h.payload_length)),
+                        want.map(|h| (h.list, h.payload_length)),
+                    ),
+                }
+                checked += 1;
+            }
+        }
+    }
+    assert!(checked > 6000, "expected a broad sweep, ran {checked}");
+}
+
+#[test]
+fn decode_node_header_accepts_every_well_formed_list() {
+    for len in LENS {
+        let mut encoded = Vec::new();
+        alloy_rlp::Header { list: true, payload_length: len }.encode(&mut encoded);
+        encoded.extend(payload(len));
+
+        let mut ours = encoded.as_slice();
+        let got = decode_node_header(&mut ours).expect("well-formed list header");
+        assert!(got.list, "len={len}");
+        assert_eq!(got.payload_length, len, "len={len}");
+        assert_eq!(ours.len(), len, "header not fully consumed: len={len}");
+    }
+}
+
+/// Reference implementation of [`decode_rlp_item`] built directly on `alloy_rlp`.
+fn reference_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), alloy_rlp::Error> {
+    let start = *buf;
+    let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
+    if buf.len() < payload_length {
+        return Err(alloy_rlp::Error::InputTooShort);
+    }
+    let header_length = start.len() - buf.len();
+    let payload = &start[header_length..header_length + payload_length];
+    *buf = &start[header_length + payload_length..];
+    Ok((&start[..header_length + payload_length], payload))
+}
+
+#[test]
+fn decode_rlp_item_matches_alloy() {
+    for filler in FILLERS {
+        for lead in 0..=u8::MAX {
+            for extra in EXTRAS {
+                let input = synthetic(lead, extra, filler);
+
+                let mut ours = input.as_slice();
+                let got = decode_rlp_item(&mut ours);
+
+                let mut theirs = input.as_slice();
+                let want = reference_item(&mut theirs);
+
+                match (got, want) {
+                    (Ok((item, pay)), Ok((ref_item, ref_pay))) => {
+                        assert_eq!(
+                            item, ref_item,
+                            "item: lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                        assert_eq!(
+                            pay, ref_pay,
+                            "payload: lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                        assert_eq!(
+                            ours.len(),
+                            theirs.len(),
+                            "advance: lead={lead:#04x} extra={extra} {filler:?}"
+                        );
+                    }
+                    (Err(_), Err(_)) => {}
+                    (got, want) => panic!(
+                        "accept/reject disagreement: lead={lead:#04x} extra={extra} {filler:?} \
+                         ours_ok={} alloy_ok={}",
+                        got.is_ok(),
+                        want.is_ok(),
+                    ),
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn decode_rlp_item_round_trips_every_string_length() {
+    for len in LENS {
+        let bytes = payload(len);
+        let mut encoded = Vec::new();
+        alloy_rlp::Encodable::encode(&bytes.as_slice(), &mut encoded);
+
+        let mut ours = encoded.as_slice();
+        let (item, pay) = decode_rlp_item(&mut ours).expect("well-formed string");
+        assert_eq!(item, encoded.as_slice(), "len={len}");
+        assert_eq!(pay, bytes.as_slice(), "len={len}");
+        assert!(ours.is_empty(), "len={len}");
+    }
+}
+
+#[test]
+fn encode_header_matches_alloy() {
+    for list in [false, true] {
+        let base_code =
+            if list { alloy_rlp::EMPTY_LIST_CODE } else { alloy_rlp::EMPTY_STRING_CODE };
+        for payload_length in (0usize..600).chain([1000, 65_535, 65_536, 1 << 20]) {
+            let mut ours = Vec::new();
+            encode_header(base_code, payload_length, &mut ours);
+
+            let mut theirs = Vec::new();
+            alloy_rlp::Header { list, payload_length }.encode(&mut theirs);
+
+            assert_eq!(ours, theirs, "list={list} payload_length={payload_length}");
+        }
+    }
+}
+
+#[test]
+fn encode_slice_matches_alloy() {
+    // Single-byte strings are the only case with a special encoding, so sweep all of them.
+    for byte in 0..=u8::MAX {
+        let bytes = [byte];
+        let mut ours = Vec::new();
+        encode_slice(&bytes, &mut ours);
+
+        let mut theirs = Vec::new();
+        alloy_rlp::Encodable::encode(&bytes.as_slice(), &mut theirs);
+
+        assert_eq!(ours, theirs, "byte={byte:#04x}");
+    }
+
+    for len in LENS {
+        let bytes = payload(len);
+        let mut ours = Vec::new();
+        encode_slice(&bytes, &mut ours);
+
+        let mut theirs = Vec::new();
+        alloy_rlp::Encodable::encode(&bytes.as_slice(), &mut theirs);
+
+        assert_eq!(ours, theirs, "len={len}");
+    }
+}
+
+#[test]
+fn is_null_ref_matches_slice_equality() {
+    for filler in FILLERS {
+        for lead in 0..=u8::MAX {
+            for extra in 0usize..3 {
+                let input = synthetic(lead, extra, filler);
+                assert_eq!(
+                    is_null_ref(&input),
+                    input.as_slice() == NULL_NODE_REF_SLICE,
+                    "lead={lead:#04x} extra={extra} {filler:?}"
+                );
+            }
+        }
+    }
+    assert!(is_null_ref(NULL_NODE_REF_SLICE));
+    assert!(!is_null_ref(&[]));
+}

--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -273,6 +273,24 @@ fn test_serde_rejects_corrupted_digest_reference() -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "host")]
+#[test]
+fn test_serde_digest_root() -> Result<(), Error> {
+    let bump = bumpalo::Bump::new();
+    let digest = bump.alloc_slice_copy(&[0xabu8; 32]);
+    let mut trie = Mpt::new(&bump);
+    let root_id = trie.add_node(NodeData::Digest(digest), None);
+    trie.set_root_id(root_id);
+
+    let encoded = trie.encode_trie();
+    let mut encoded_slice = encoded.as_slice();
+    let recovered_trie = Mpt::decode_trie(&bump, &mut encoded_slice, trie.num_nodes())?;
+
+    assert!(encoded_slice.is_empty());
+    assert_eq!(recovered_trie.hash(), B256::from_slice(digest));
+    Ok(())
+}
+
 /// Test that deleting a key that would cause branch collapse fails if sibling is unresolved Digest.
 /// This tests the soundness fix: we must not assume an unresolved Digest is a Branch node.
 #[test]

--- a/crates/mpt/src/tests.rs
+++ b/crates/mpt/src/tests.rs
@@ -1,6 +1,9 @@
 use revm_primitives::{b256, keccak256, B256};
 
-use crate::{node::NodeData, Error, Mpt};
+use crate::{
+    node::{BranchChildId, NodeData},
+    Error, Mpt,
+};
 
 trait RlpBytes {
     /// Returns the RLP-encoding.
@@ -299,9 +302,9 @@ fn test_delete_with_unresolved_sibling_errors() {
     let digest_id = trie.add_node(NodeData::Digest(fake_digest), None);
 
     // Create a branch with these two children
-    let mut children: [Option<u32>; 16] = Default::default();
-    children[0] = Some(leaf_id);
-    children[1] = Some(digest_id);
+    let mut children: [Option<BranchChildId>; 16] = Default::default();
+    children[0] = BranchChildId::new(leaf_id);
+    children[1] = BranchChildId::new(digest_id);
     let branch_children = trie.alloc_branch(children);
     let branch_node_id = trie.add_node(NodeData::Branch(branch_children), None);
 

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -17,7 +17,7 @@ use crate::{
         encoded_path_eq_key, encoded_path_from_key, encoded_path_strip_prefix_key, lcp_key,
         prefix_to_nibs, to_encoded_path_with_bump, KeyNibbles,
     },
-    node::{BranchChildren, NodeData, NodeId, NodeRef},
+    node::{BranchChildId, BranchChildren, NodeData, NodeId, NodeRef},
 };
 
 /// OpenVM memory alignment word size.
@@ -153,6 +153,14 @@ fn put_digest<B: alloy_rlp::BufMut>(digest: &[u8], out: &mut B) {
     }
 }
 
+/// Converts a node id to a branch child slot id.
+/// The only zero id is the null-node sentinel ([`NULL_NODE_ID`]), which is never stored as a
+/// branch child.
+#[inline(always)]
+fn branch_child_id(node_id: NodeId) -> BranchChildId {
+    BranchChildId::new(node_id).expect("the null-node sentinel is never a branch child")
+}
+
 /// Writes an RLP header with the given base code (`EMPTY_LIST_CODE` for lists,
 /// `EMPTY_STRING_CODE` for strings). Emits the same bytes as [`alloy_rlp::Header::encode`], but
 /// is generic over the output buffer: `alloy_rlp` encoding goes through `&mut dyn BufMut`, and
@@ -210,7 +218,7 @@ impl<'a> Mpt<'a> {
         match self.nodes[node_id as usize] {
             NodeData::Branch(children) => {
                 for child_id in children.iter().filter_map(Cell::get) {
-                    self.encode_trie_internal(child_id, out);
+                    self.encode_trie_internal(child_id.get(), out);
                 }
             }
             NodeData::Extension(_, ext_id) => {
@@ -364,7 +372,7 @@ impl<'a> Mpt<'a> {
             if is_null_ref(child0_expected_node_ref.as_slice()) {
                 None
             } else {
-                Some(self.decode_trie_internal(bytes, child0_expected_node_ref)?)
+                Some(branch_child_id(self.decode_trie_internal(bytes, child0_expected_node_ref)?))
             }
         };
 
@@ -373,7 +381,7 @@ impl<'a> Mpt<'a> {
             if is_null_ref(child1_expected_node_ref.as_slice()) {
                 None
             } else {
-                Some(self.decode_trie_internal(bytes, child1_expected_node_ref)?)
+                Some(branch_child_id(self.decode_trie_internal(bytes, child1_expected_node_ref)?))
             }
         };
 
@@ -385,8 +393,8 @@ impl<'a> Mpt<'a> {
         let childs = unsafe {
             &mut *self
                 .bump
-                .alloc_layout(Layout::new::<[Cell<Option<NodeId>>; 16]>())
-                .cast::<[MaybeUninit<Option<NodeId>>; 16]>()
+                .alloc_layout(Layout::new::<[Cell<Option<BranchChildId>>; 16]>())
+                .cast::<[MaybeUninit<Option<BranchChildId>>; 16]>()
                 .as_ptr()
         };
 
@@ -410,7 +418,9 @@ impl<'a> Mpt<'a> {
                 if is_null_ref(child_expected_node_ref.as_slice()) {
                     None
                 } else {
-                    Some(self.decode_trie_internal(bytes, child_expected_node_ref)?)
+                    Some(branch_child_id(
+                        self.decode_trie_internal(bytes, child_expected_node_ref)?,
+                    ))
                 }
             });
         }
@@ -423,8 +433,8 @@ impl<'a> Mpt<'a> {
         // SAFETY: all elements of the array were initialized above, and `Cell<T>` is
         // `repr(transparent)` over `T`.
         let children: BranchChildren<'a> = unsafe {
-            &*(childs as *const [MaybeUninit<Option<NodeId>>; 16]
-                as *const [Cell<Option<NodeId>>; 16])
+            &*(childs as *const [MaybeUninit<Option<BranchChildId>>; 16]
+                as *const [Cell<Option<BranchChildId>>; 16])
         };
         let node_id = self.add_node(NodeData::Branch(children), Some(node_ref));
         Ok(node_id)
@@ -483,7 +493,7 @@ impl<'a> Mpt<'a> {
                 encode_header(alloy_rlp::EMPTY_LIST_CODE, payload_length, out);
                 for child_id in children.iter() {
                     match child_id.get() {
-                        Some(id) => self.reference_encode(id, out),
+                        Some(id) => self.reference_encode(id.get(), out),
                         None => out.put_u8(alloy_rlp::EMPTY_STRING_CODE),
                     }
                 }
@@ -536,7 +546,7 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 1 + children
                     .iter()
-                    .map(|child| child.get().map_or(1, |id| self.reference_length(id)))
+                    .map(|child| child.get().map_or(1, |id| self.reference_length(id.get())))
                     .sum::<usize>()
             }
             NodeData::Leaf(encoded_path, value) => encoded_path.length() + value.length(),
@@ -662,7 +672,7 @@ impl<'a> Mpt<'a> {
     /// Allocates a branch children array in the bump arena, to be stored in a
     /// [`NodeData::Branch`].
     #[inline]
-    pub(crate) fn alloc_branch(&self, children: [Option<NodeId>; 16]) -> BranchChildren<'a> {
+    pub(crate) fn alloc_branch(&self, children: [Option<BranchChildId>; 16]) -> BranchChildren<'a> {
         self.bump.alloc(children.map(Cell::new))
     }
 
@@ -711,7 +721,7 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
-                        Some(id) => self.get_internal(id, tail),
+                        Some(id) => self.get_internal(id.get(), tail),
                         None => Ok(None),
                     }
                 } else {
@@ -754,11 +764,11 @@ impl<'a> Mpt<'a> {
             NodeData::Branch(children) => {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
-                        Some(id) => self.insert_internal(id, tail, value)?,
+                        Some(id) => self.insert_internal(id.get(), tail, value)?,
                         None => {
                             let path = encoded_path_from_key(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            children[usize::from(i)].set(Some(new_leaf_id));
+                            children[usize::from(i)].set(Some(branch_child_id(new_leaf_id)));
                             true
                         }
                     }
@@ -783,7 +793,7 @@ impl<'a> Mpt<'a> {
                     } else {
                         // otherwise, create a branch with two children
                         let split_point = common_len + 1;
-                        let mut children: [Option<NodeId>; 16] = Default::default();
+                        let mut children: [Option<BranchChildId>; 16] = Default::default();
 
                         let leaf1_path =
                             to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], true);
@@ -793,8 +803,9 @@ impl<'a> Mpt<'a> {
                             encoded_path_from_key(self.bump, key.advanced(split_point), true);
                         let leaf2_id = self.add_node(NodeData::Leaf(leaf2_path, value), None);
 
-                        children[self_nibs[common_len] as usize] = Some(leaf1_id);
-                        children[usize::from(key.nib(common_len))] = Some(leaf2_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(leaf1_id));
+                        children[usize::from(key.nib(common_len))] =
+                            Some(branch_child_id(leaf2_id));
 
                         let branch_children = self.alloc_branch(children);
                         let new_node_data = if common_len > 0 {
@@ -825,21 +836,21 @@ impl<'a> Mpt<'a> {
                         return Err(Error::ValueInBranch);
                     }
                     let split_point = common_len + 1;
-                    let mut children: [Option<NodeId>; 16] = Default::default();
+                    let mut children: [Option<BranchChildId>; 16] = Default::default();
 
                     if split_point < self_nibs.len() {
                         let ext_path =
                             to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], false);
                         let ext_id = self.add_node(NodeData::Extension(ext_path, child_id), None);
-                        children[self_nibs[common_len] as usize] = Some(ext_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(ext_id));
                     } else {
-                        children[self_nibs[common_len] as usize] = Some(child_id);
+                        children[self_nibs[common_len] as usize] = Some(branch_child_id(child_id));
                     }
 
                     let leaf_path =
                         encoded_path_from_key(self.bump, key.advanced(split_point), true);
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
-                    children[usize::from(key.nib(common_len))] = Some(leaf_id);
+                    children[usize::from(key.nib(common_len))] = Some(branch_child_id(leaf_id));
 
                     let branch_children = self.alloc_branch(children);
                     let new_node_data = if common_len > 0 {
@@ -874,6 +885,7 @@ impl<'a> Mpt<'a> {
                 if let Some((i, tail)) = key.split_first() {
                     match children[usize::from(i)].get() {
                         Some(id) => {
+                            let id = id.get();
                             if !self.delete_internal(id, tail)? {
                                 return Ok(false);
                             }
@@ -892,7 +904,7 @@ impl<'a> Mpt<'a> {
                 let mut remaining_iter = children
                     .iter()
                     .enumerate()
-                    .filter_map(|(index, n)| n.get().map(|id| (index, id)));
+                    .filter_map(|(index, n)| n.get().map(|id| (index, id.get())));
 
                 // there will always be at least one remaining node
                 let (index, child_id) = remaining_iter.next().unwrap();
@@ -1040,10 +1052,11 @@ impl<'a> Mpt<'a> {
                         return Err(Error::ValueInBranch);
                     }
 
-                    let mut childs: [Option<NodeId>; 16] = Default::default();
+                    let mut childs: [Option<BranchChildId>; 16] = Default::default();
                     for (i, mut item) in items.into_iter().take(16).enumerate() {
                         let child_id = self.decode_from_proof_rlp_internal(&mut item)?;
-                        childs[i] = if child_id == NULL_NODE_ID { None } else { Some(child_id) };
+                        // `BranchChildId::new` maps the `NULL_NODE_ID` sentinel (0) to `None`.
+                        childs[i] = BranchChildId::new(child_id);
                     }
                     let children = self.alloc_branch(childs);
                     self.add_node(NodeData::Branch(children), None)
@@ -1076,7 +1089,7 @@ impl<'a> Mpt<'a> {
         match &self.nodes[node_id as usize] {
             NodeData::Branch(children) => {
                 for child_id in children.iter().filter_map(Cell::get) {
-                    self.payloads_internal(child_id, payloads);
+                    self.payloads_internal(child_id.get(), payloads);
                 }
             }
             NodeData::Extension(_, ext_id) => {
@@ -1105,7 +1118,7 @@ impl Mpt<'_> {
                 for (i, child) in children.iter().enumerate() {
                     if let Some(child_id) = child.get() {
                         println!("{}  [{}]:", indent, hex::encode([i as u8]));
-                        self.print_trie_internal(child_id, depth + 2);
+                        self.print_trie_internal(child_id.get(), depth + 2);
                     }
                 }
             }

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -14,8 +14,8 @@ use smallvec::SmallVec;
 use crate::{
     bump_bufmut::BumpBytesMut,
     hp::{
-        encoded_path_eq_nibs, encoded_path_strip_prefix, lcp, prefix_to_nibs,
-        to_encoded_path_with_bump, to_nibs,
+        encoded_path_eq_key, encoded_path_from_key, encoded_path_strip_prefix_key, lcp_key,
+        prefix_to_nibs, to_encoded_path_with_bump, KeyNibbles,
     },
     node::{BranchChildren, NodeData, NodeId, NodeRef},
 };
@@ -594,7 +594,7 @@ impl<'a> Mpt<'a> {
     /// Retrieves the value associated with a given key in the trie.
     #[inline]
     pub fn get<'s>(&'s self, key: &[u8]) -> Result<Option<&'a [u8]>, Error> {
-        self.get_internal(self.root_id, &to_nibs(key))
+        self.get_internal(self.root_id, KeyNibbles::new(key))
     }
 
     /// Retrieves the RLP-decoded value corresponding to the key.
@@ -612,8 +612,7 @@ impl<'a> Mpt<'a> {
     /// Inserts a key-value pair into the trie.
     #[inline]
     pub fn insert(&mut self, key: &[u8], value: &'a [u8]) -> Result<bool, Error> {
-        let key_nibs = &to_nibs(key);
-        self.insert_internal(self.root_id, key_nibs, value)
+        self.insert_internal(self.root_id, KeyNibbles::new(key), value)
     }
 
     /// Inserts an RLP-encoded value into the trie.
@@ -634,8 +633,7 @@ impl<'a> Mpt<'a> {
     /// present, it returns `true`. Otherwise, it returns `false`.
     #[inline]
     pub fn delete(&mut self, key: &[u8]) -> Result<bool, Error> {
-        let key_nibs = &to_nibs(key);
-        self.delete_internal(self.root_id, key_nibs)
+        self.delete_internal(self.root_id, KeyNibbles::new(key))
     }
 
     #[inline]
@@ -703,12 +701,16 @@ impl<'a> Mpt<'a> {
     }
 
     #[inline]
-    fn get_internal(&self, node_id: NodeId, key_nibs: &[u8]) -> Result<Option<&'a [u8]>, Error> {
+    fn get_internal(
+        &self,
+        node_id: NodeId,
+        key: KeyNibbles<'_>,
+    ) -> Result<Option<&'a [u8]>, Error> {
         match &self.nodes[node_id as usize] {
             NodeData::Null => Ok(None),
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => self.get_internal(id, tail),
                         None => Ok(None),
                     }
@@ -718,7 +720,7 @@ impl<'a> Mpt<'a> {
             }
             NodeData::Leaf(path_bytes, value) => {
                 // Compare compact path to key nibbles without allocating
-                if encoded_path_eq_nibs(path_bytes, key_nibs) {
+                if encoded_path_eq_key(path_bytes, key) {
                     Ok(Some(value))
                 } else {
                     Ok(None)
@@ -726,7 +728,7 @@ impl<'a> Mpt<'a> {
             }
             NodeData::Extension(path_bytes, child_id) => {
                 // Strip compact path prefix without allocating
-                if let Some(tail) = encoded_path_strip_prefix(path_bytes, key_nibs) {
+                if let Some(tail) = encoded_path_strip_prefix_key(path_bytes, key) {
                     self.get_internal(*child_id, tail)
                 } else {
                     Ok(None)
@@ -740,23 +742,23 @@ impl<'a> Mpt<'a> {
     fn insert_internal(
         &mut self,
         node_id: NodeId,
-        key_nibs: &[u8],
+        key: KeyNibbles<'_>,
         value: &'a [u8],
     ) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => {
-                let path = to_encoded_path_with_bump(self.bump, key_nibs, true);
+                let path = encoded_path_from_key(self.bump, key, true);
                 self.nodes[node_id as usize] = NodeData::Leaf(path, value);
                 true
             }
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => self.insert_internal(id, tail, value)?,
                         None => {
-                            let path = to_encoded_path_with_bump(self.bump, tail, true);
+                            let path = encoded_path_from_key(self.bump, tail, true);
                             let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
-                            children[*i as usize].set(Some(new_leaf_id));
+                            children[usize::from(i)].set(Some(new_leaf_id));
                             true
                         }
                     }
@@ -765,7 +767,7 @@ impl<'a> Mpt<'a> {
                 }
             }
             NodeData::Leaf(prefix, old_value) => {
-                if encoded_path_eq_nibs(prefix, key_nibs) {
+                if encoded_path_eq_key(prefix, key) {
                     // update the value if it is different
                     if old_value == value {
                         return Ok(false);
@@ -774,9 +776,9 @@ impl<'a> Mpt<'a> {
                     true
                 } else {
                     let self_nibs = prefix_to_nibs(prefix);
-                    let common_len = lcp(&self_nibs, key_nibs);
+                    let common_len = lcp_key(&self_nibs, key);
 
-                    if common_len == self_nibs.len() || common_len == key_nibs.len() {
+                    if common_len == self_nibs.len() || common_len == key.remaining() {
                         return Err(Error::ValueInBranch);
                     } else {
                         // otherwise, create a branch with two children
@@ -788,11 +790,11 @@ impl<'a> Mpt<'a> {
                         let leaf1_id = self.add_node(NodeData::Leaf(leaf1_path, old_value), None);
 
                         let leaf2_path =
-                            to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                            encoded_path_from_key(self.bump, key.advanced(split_point), true);
                         let leaf2_id = self.add_node(NodeData::Leaf(leaf2_path, value), None);
 
                         children[self_nibs[common_len] as usize] = Some(leaf1_id);
-                        children[key_nibs[common_len] as usize] = Some(leaf2_id);
+                        children[usize::from(key.nib(common_len))] = Some(leaf2_id);
 
                         let branch_children = self.alloc_branch(children);
                         let new_node_data = if common_len > 0 {
@@ -813,13 +815,13 @@ impl<'a> Mpt<'a> {
                 }
             }
             NodeData::Extension(prefix, child_id) => {
-                if let Some(tail) = encoded_path_strip_prefix(prefix, key_nibs) {
+                if let Some(tail) = encoded_path_strip_prefix_key(prefix, key) {
                     self.insert_internal(child_id, tail, value)?
                 } else {
                     let self_nibs = prefix_to_nibs(prefix);
-                    let common_len = lcp(&self_nibs, key_nibs);
+                    let common_len = lcp_key(&self_nibs, key);
 
-                    if common_len == key_nibs.len() {
+                    if common_len == key.remaining() {
                         return Err(Error::ValueInBranch);
                     }
                     let split_point = common_len + 1;
@@ -835,9 +837,9 @@ impl<'a> Mpt<'a> {
                     }
 
                     let leaf_path =
-                        to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                        encoded_path_from_key(self.bump, key.advanced(split_point), true);
                     let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
-                    children[key_nibs[common_len] as usize] = Some(leaf_id);
+                    children[usize::from(key.nib(common_len))] = Some(leaf_id);
 
                     let branch_children = self.alloc_branch(children);
                     let new_node_data = if common_len > 0 {
@@ -865,12 +867,12 @@ impl<'a> Mpt<'a> {
     }
 
     #[inline]
-    fn delete_internal(&mut self, node_id: NodeId, key_nibs: &[u8]) -> Result<bool, Error> {
+    fn delete_internal(&mut self, node_id: NodeId, key: KeyNibbles<'_>) -> Result<bool, Error> {
         let updated = match self.nodes[node_id as usize] {
             NodeData::Null => false,
             NodeData::Branch(children) => {
-                if let Some((i, tail)) = key_nibs.split_first() {
-                    match children[*i as usize].get() {
+                if let Some((i, tail)) = key.split_first() {
+                    match children[usize::from(i)].get() {
                         Some(id) => {
                             if !self.delete_internal(id, tail)? {
                                 return Ok(false);
@@ -878,7 +880,7 @@ impl<'a> Mpt<'a> {
 
                             // if the node is now empty, remove it
                             if matches!(self.nodes[id as usize], NodeData::Null) {
-                                children[*i as usize].set(None);
+                                children[usize::from(i)].set(None);
                             }
                         }
                         None => return Ok(false),
@@ -935,14 +937,14 @@ impl<'a> Mpt<'a> {
                 true
             }
             NodeData::Leaf(prefix, _) => {
-                if !encoded_path_eq_nibs(prefix, key_nibs) {
+                if !encoded_path_eq_key(prefix, key) {
                     return Ok(false);
                 }
                 self.nodes[node_id as usize] = NodeData::Null;
                 true
             }
             NodeData::Extension(prefix, child_id) => {
-                let tail = match encoded_path_strip_prefix(prefix, key_nibs) {
+                let tail = match encoded_path_strip_prefix_key(prefix, key) {
                     Some(tail) => tail,
                     None => return Ok(false),
                 };

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -106,6 +106,80 @@ unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
     bytes
 }
 
+/// Decodes and advances past one RLP item, returning its full encoding and payload. Common
+/// single-byte headers are handled directly, with the generic decoder as a fallback.
+#[inline(always)]
+fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error> {
+    let item_start = *buf;
+    if item_start.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
+        *buf = &item_start[1..];
+        return Ok((&item_start[..1], &item_start[1..1]));
+    }
+    if item_start.first() == Some(&(alloy_rlp::EMPTY_STRING_CODE + 32)) {
+        let item = item_start.get(..33).ok_or(alloy_rlp::Error::InputTooShort)?;
+        *buf = &item_start[33..];
+        return Ok((item, &item[1..]));
+    }
+    if let Some(code @ 0x81..=0xb7) = item_start.first().copied() {
+        let payload_length = usize::from(code - alloy_rlp::EMPTY_STRING_CODE);
+        let item = item_start.get(..payload_length + 1).ok_or(alloy_rlp::Error::InputTooShort)?;
+        let payload = &item[1..];
+        if payload_length == 1 && payload[0] < alloy_rlp::EMPTY_STRING_CODE {
+            return Err(alloy_rlp::Error::NonCanonicalSingleByte.into());
+        }
+        *buf = &item_start[payload_length + 1..];
+        return Ok((item, payload));
+    }
+
+    let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
+    // SAFETY: the header was decoded, so the item contains its declared payload.
+    let payload = unsafe { advance_unchecked(buf, payload_length) };
+    let item_length = item_start.len() - buf.len();
+    Ok((&item_start[..item_length], payload))
+}
+
+/// Decodes an MPT node header, specializing the canonical list headers used by resolved nodes.
+/// The generic decoder remains the fallback for strings and larger lists.
+#[inline(always)]
+fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
+    let input = *buf;
+    match input.first().copied() {
+        Some(code @ alloy_rlp::EMPTY_LIST_CODE..=0xf7) => {
+            let payload_length = usize::from(code - alloy_rlp::EMPTY_LIST_CODE);
+            if input.len() < payload_length + 1 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[1..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf8) => {
+            let payload_length = usize::from(*input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?);
+            if payload_length < 56 {
+                return Err(alloy_rlp::Error::NonCanonicalSize.into());
+            }
+            if input.len() < payload_length + 2 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[2..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        Some(0xf9) => {
+            let high = *input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?;
+            let low = *input.get(2).ok_or(alloy_rlp::Error::InputTooShort)?;
+            if high == 0 {
+                return Err(alloy_rlp::Error::LeadingZero.into());
+            }
+            let payload_length = (usize::from(high) << 8) | usize::from(low);
+            if input.len() < payload_length + 3 {
+                return Err(alloy_rlp::Error::InputTooShort.into());
+            }
+            *buf = &input[3..];
+            Ok(alloy_rlp::Header { list: true, payload_length })
+        }
+        _ => alloy_rlp::Header::decode(buf).map_err(Into::into),
+    }
+}
+
 /// Whether `slice` is the RLP encoding of an empty node reference: a single `EMPTY_STRING_CODE`
 /// byte. Written as an explicit pattern match because comparing against [`NULL_NODE_REF_SLICE`]
 /// with `==` compiles to a `memcmp` call, whose overhead dwarfs this one-byte check — and trie
@@ -286,8 +360,23 @@ impl<'a> Mpt<'a> {
         bytes: &mut &'a [u8],
         expected_node_ref: NodeRef<'a>,
     ) -> Result<NodeId, Error> {
+        // Unresolved nodes are encoded as a 32-byte RLP string followed by three alignment bytes.
+        // They are common at the witness boundary and have a fixed representation, so avoid the
+        // generic header decoder and the general node-kind dispatch.
+        if bytes.first() == Some(&(alloy_rlp::EMPTY_STRING_CODE + 32)) {
+            // SAFETY: as elsewhere in this decoder, the witness encoding is expected to contain
+            // the declared RLP payload and its alignment padding.
+            let encoded = unsafe { advance_unchecked(bytes, 33) };
+            unsafe { advance_unchecked(bytes, 3) };
+            let digest = &encoded[1..];
+            if !digest_eq(digest, expected_node_ref.as_slice()) {
+                return Err(Error::NodeRefMismatch);
+            }
+            return Ok(self.add_node(NodeData::Digest(digest), Some(NodeRef::Digest(digest))));
+        }
+
         let rlp_node_header_start = *bytes;
-        let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(bytes)?;
+        let alloy_rlp::Header { list, payload_length } = decode_node_header(bytes)?;
 
         // SAFETY: we already decoded the header, so we know the payload length.
         let mut payload = unsafe { advance_unchecked(bytes, payload_length) };
@@ -331,56 +420,41 @@ impl<'a> Mpt<'a> {
             return Ok(node_id);
         }
 
-        // first payload item
-        let item0_header_start = payload;
-        let alloy_rlp::Header { payload_length: item0_payload_length, .. } =
-            alloy_rlp::Header::decode(&mut payload)?;
-        // SAFETY: we already decoded the header, so we know the payload length.
-        let item0_payload_start = unsafe { advance_unchecked(&mut payload, item0_payload_length) };
-        let item0_length = item0_header_start.len() - payload.len();
-
-        // second payload item
-        let item1_header_start = payload;
-        let alloy_rlp::Header { payload_length: item1_payload_length, .. } =
-            alloy_rlp::Header::decode(&mut payload)?;
-        // SAFETY: we already decoded the header, so we know the payload length.
-        let item1_payload_start = unsafe { advance_unchecked(&mut payload, item1_payload_length) };
-        let item1_length = item1_header_start.len() - payload.len();
+        let (item0, item0_payload) = decode_rlp_item(&mut payload)?;
+        let (item1, item1_payload) = decode_rlp_item(&mut payload)?;
 
         if payload.is_empty() {
             // either an extension or leaf
-            let path = &item0_payload_start[..item0_payload_length];
+            let path = item0_payload;
             let prefix = path[0];
             if (prefix & (2 << 4)) == 0 {
                 // extension node
-                let ext_node_expected_ref =
-                    NodeRef::from_rlp_slice(&item1_header_start[..item1_length]);
+                let ext_node_expected_ref = NodeRef::from_rlp_slice(item1);
                 let ext_node_id = self.decode_trie_internal(bytes, ext_node_expected_ref)?;
                 let node_data = NodeData::Extension(path, ext_node_id);
                 return Ok(self.add_node(node_data, Some(node_ref)));
             } else {
                 // leaf node
-                let value = &item1_payload_start[..item1_payload_length];
-                let node_data = NodeData::Leaf(path, value);
+                let node_data = NodeData::Leaf(path, item1_payload);
                 return Ok(self.add_node(node_data, Some(node_ref)));
             }
         }
 
         // branch
-        let child0_expected_node_ref = NodeRef::from_rlp_slice(&item0_header_start[..item0_length]);
         let child0 = {
-            if is_null_ref(child0_expected_node_ref.as_slice()) {
+            if is_null_ref(item0) {
                 None
             } else {
+                let child0_expected_node_ref = NodeRef::from_rlp_slice(item0);
                 Some(branch_child_id(self.decode_trie_internal(bytes, child0_expected_node_ref)?))
             }
         };
 
-        let child1_expected_node_ref = NodeRef::from_rlp_slice(&item1_header_start[..item1_length]);
         let child1 = {
-            if is_null_ref(child1_expected_node_ref.as_slice()) {
+            if is_null_ref(item1) {
                 None
             } else {
+                let child1_expected_node_ref = NodeRef::from_rlp_slice(item1);
                 Some(branch_child_id(self.decode_trie_internal(bytes, child1_expected_node_ref)?))
             }
         };
@@ -404,20 +478,13 @@ impl<'a> Mpt<'a> {
 
         // Initialize remaining elements
         for child in &mut childs[2..] {
-            let item_header_start = payload;
-            let alloy_rlp::Header { payload_length: item_payload_length, .. } =
-                alloy_rlp::Header::decode(&mut payload)?;
-            // SAFETY: we already decoded the header, so we know the payload length.
-            unsafe { advance_unchecked(&mut payload, item_payload_length) };
-            let item_length = item_header_start.len() - payload.len();
-
-            let child_expected_node_ref =
-                NodeRef::from_rlp_slice(&item_header_start[..item_length]);
+            let (item, _) = decode_rlp_item(&mut payload)?;
 
             *child = MaybeUninit::new({
-                if is_null_ref(child_expected_node_ref.as_slice()) {
+                if is_null_ref(item) {
                     None
                 } else {
+                    let child_expected_node_ref = NodeRef::from_rlp_slice(item);
                     Some(branch_child_id(
                         self.decode_trie_internal(bytes, child_expected_node_ref)?,
                     ))

--- a/crates/mpt/src/trie.rs
+++ b/crates/mpt/src/trie.rs
@@ -7,7 +7,6 @@ use core::{
 
 use alloy_rlp::Encodable;
 use bumpalo::Bump;
-use bytes::Buf;
 use revm_primitives::{keccak256, B256};
 use smallvec::SmallVec;
 
@@ -18,6 +17,10 @@ use crate::{
         prefix_to_nibs, to_encoded_path_with_bump, KeyNibbles,
     },
     node::{BranchChildId, BranchChildren, NodeData, NodeId, NodeRef},
+    rlp::{
+        advance_unchecked, decode_node_header, decode_rlp_item, encode_header, encode_slice,
+        is_null_ref, NULL_NODE_REF_SLICE,
+    },
 };
 
 /// OpenVM memory alignment word size.
@@ -98,97 +101,6 @@ impl<'a> Mpt<'a> {
     }
 }
 
-/// Same as `let (bytes, rest) = buf.split_at(cnt); *buf = rest; bytes`.
-#[inline(always)]
-unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
-    let bytes = &buf[..cnt];
-    buf.advance(cnt);
-    bytes
-}
-
-/// Decodes and advances past one RLP item, returning its full encoding and payload. Common
-/// single-byte headers are handled directly, with the generic decoder as a fallback.
-#[inline(always)]
-fn decode_rlp_item<'a>(buf: &mut &'a [u8]) -> Result<(&'a [u8], &'a [u8]), Error> {
-    let item_start = *buf;
-    if item_start.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
-        *buf = &item_start[1..];
-        return Ok((&item_start[..1], &item_start[1..1]));
-    }
-    if item_start.first() == Some(&(alloy_rlp::EMPTY_STRING_CODE + 32)) {
-        let item = item_start.get(..33).ok_or(alloy_rlp::Error::InputTooShort)?;
-        *buf = &item_start[33..];
-        return Ok((item, &item[1..]));
-    }
-    if let Some(code @ 0x81..=0xb7) = item_start.first().copied() {
-        let payload_length = usize::from(code - alloy_rlp::EMPTY_STRING_CODE);
-        let item = item_start.get(..payload_length + 1).ok_or(alloy_rlp::Error::InputTooShort)?;
-        let payload = &item[1..];
-        if payload_length == 1 && payload[0] < alloy_rlp::EMPTY_STRING_CODE {
-            return Err(alloy_rlp::Error::NonCanonicalSingleByte.into());
-        }
-        *buf = &item_start[payload_length + 1..];
-        return Ok((item, payload));
-    }
-
-    let alloy_rlp::Header { payload_length, .. } = alloy_rlp::Header::decode(buf)?;
-    // SAFETY: the header was decoded, so the item contains its declared payload.
-    let payload = unsafe { advance_unchecked(buf, payload_length) };
-    let item_length = item_start.len() - buf.len();
-    Ok((&item_start[..item_length], payload))
-}
-
-/// Decodes an MPT node header, specializing the canonical list headers used by resolved nodes.
-/// The generic decoder remains the fallback for strings and larger lists.
-#[inline(always)]
-fn decode_node_header(buf: &mut &[u8]) -> Result<alloy_rlp::Header, Error> {
-    let input = *buf;
-    match input.first().copied() {
-        Some(code @ alloy_rlp::EMPTY_LIST_CODE..=0xf7) => {
-            let payload_length = usize::from(code - alloy_rlp::EMPTY_LIST_CODE);
-            if input.len() < payload_length + 1 {
-                return Err(alloy_rlp::Error::InputTooShort.into());
-            }
-            *buf = &input[1..];
-            Ok(alloy_rlp::Header { list: true, payload_length })
-        }
-        Some(0xf8) => {
-            let payload_length = usize::from(*input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?);
-            if payload_length < 56 {
-                return Err(alloy_rlp::Error::NonCanonicalSize.into());
-            }
-            if input.len() < payload_length + 2 {
-                return Err(alloy_rlp::Error::InputTooShort.into());
-            }
-            *buf = &input[2..];
-            Ok(alloy_rlp::Header { list: true, payload_length })
-        }
-        Some(0xf9) => {
-            let high = *input.get(1).ok_or(alloy_rlp::Error::InputTooShort)?;
-            let low = *input.get(2).ok_or(alloy_rlp::Error::InputTooShort)?;
-            if high == 0 {
-                return Err(alloy_rlp::Error::LeadingZero.into());
-            }
-            let payload_length = (usize::from(high) << 8) | usize::from(low);
-            if input.len() < payload_length + 3 {
-                return Err(alloy_rlp::Error::InputTooShort.into());
-            }
-            *buf = &input[3..];
-            Ok(alloy_rlp::Header { list: true, payload_length })
-        }
-        _ => alloy_rlp::Header::decode(buf).map_err(Into::into),
-    }
-}
-
-/// Whether `slice` is the RLP encoding of an empty node reference: a single `EMPTY_STRING_CODE`
-/// byte. Written as an explicit pattern match because comparing against [`NULL_NODE_REF_SLICE`]
-/// with `==` compiles to a `memcmp` call, whose overhead dwarfs this one-byte check — and trie
-/// decoding performs it for every branch child.
-#[inline(always)]
-fn is_null_ref(slice: &[u8]) -> bool {
-    matches!(slice, [byte] if *byte == alloy_rlp::EMPTY_STRING_CODE)
-}
-
 /// Byte-slice equality as an explicit loop. Slice `==` on slices of unknown length compiles to a
 /// `memcmp` call; the node references compared during decoding are at most 33 bytes, where the
 /// call overhead dominates an inline loop. Prefer [`digest_eq`] whenever one side is a full-length
@@ -233,36 +145,6 @@ fn put_digest<B: alloy_rlp::BufMut>(digest: &[u8], out: &mut B) {
 #[inline(always)]
 fn branch_child_id(node_id: NodeId) -> BranchChildId {
     BranchChildId::new(node_id).expect("the null-node sentinel is never a branch child")
-}
-
-/// Writes an RLP header with the given base code (`EMPTY_LIST_CODE` for lists,
-/// `EMPTY_STRING_CODE` for strings). Emits the same bytes as [`alloy_rlp::Header::encode`], but
-/// is generic over the output buffer: `alloy_rlp` encoding goes through `&mut dyn BufMut`, and
-/// the resulting per-write dynamic dispatch is expensive in the zkVM.
-#[inline]
-fn encode_header<B: alloy_rlp::BufMut>(base_code: u8, payload_length: usize, out: &mut B) {
-    if payload_length < 56 {
-        out.put_u8(base_code + payload_length as u8);
-    } else {
-        let len_be = payload_length.to_be_bytes();
-        let num_len_bytes = alloy_rlp::length_of_length(payload_length) - 1;
-        out.put_u8(base_code + 55 + num_len_bytes as u8);
-        out.put_slice(&len_be[len_be.len() - num_len_bytes..]);
-    }
-}
-
-/// RLP-encodes a byte slice as a string. Emits the same bytes as `Encodable for [u8]`, without
-/// dynamic dispatch (see [`encode_header`]).
-#[inline]
-fn encode_slice<B: alloy_rlp::BufMut>(bytes: &[u8], out: &mut B) {
-    if let [byte] = bytes {
-        if *byte < alloy_rlp::EMPTY_STRING_CODE {
-            out.put_u8(*byte);
-            return;
-        }
-    }
-    encode_header(alloy_rlp::EMPTY_STRING_CODE, bytes.len(), out);
-    out.put_slice(bytes);
 }
 
 impl<'a> Mpt<'a> {
@@ -507,8 +389,6 @@ impl<'a> Mpt<'a> {
         Ok(node_id)
     }
 }
-
-pub(crate) const NULL_NODE_REF_SLICE: &[u8] = &[alloy_rlp::EMPTY_STRING_CODE];
 
 impl<'a> Mpt<'a> {
     #[inline]


### PR DESCRIPTION
Replaces #664, #666 and #667, which were three stacked PRs expressing one idea: reach the RLP encodings a trie witness actually contains without walking `alloy_rlp`'s general header space. Splitting one idea across three stacked PRs cost more to review than it saved, so they are collapsed here.

Stacked on #658.

Two commits:

1. **Specialize the RLP shapes** — the union of the three PRs, with the unrelated storage-trie cache (now #683) removed from the ancestry.
2. **Move RLP handling into its own module, with differential tests** — the specializations were inline fast paths and match arms scattered through a 1129-line `trie.rs`. `decode_rlp_item`, `decode_node_header`, `is_null_ref`, `encode_header`, `encode_slice`, `advance_unchecked` and `NULL_NODE_REF_SLICE` move to `crates/mpt/src/rlp.rs`; `bytes_eq` and `branch_child_id` stay, since they are not RLP.

## Why the module matters

Hand-specialized RLP invites exactly one question — does it agree with the general implementation on every input? Previously that was only covered indirectly, through trie round-trips. Behind a module boundary each specialization is compared against `alloy_rlp` directly:

- `decode_node_header_matches_alloy` / `decode_rlp_item_matches_alloy` sweep every leading byte `0x00..=0xff` — the dimension that selects which specialized arm runs — against payload lengths straddling the 1-, 2- and 3-byte length-prefix boundaries, and against three fillers for the bytes after the lead. Most combinations are invalid RLP, which is the point: the specialized decoder must reject exactly what `alloy_rlp` rejects.

  The filler dimension matters more than it looks. For the header forms carrying a multi-byte length, the bytes after the lead *are* the declared length, so a single filler pins each of those arms to one length value. Sweeping all-zero and all-ones fillers alongside the pattern is what reaches the canonicality rules — a length with a leading zero, a long-form length below 56, and a maximal one. I checked this holds by mutation: deleting the `0xf9` leading-zero rejection leaves every test passing under a fixed filler, and fails `decode_node_header_matches_alloy` with the sweep.
- `encode_header_matches_alloy` covers payload lengths `0..600` plus `65_535`, `65_536` and `1 << 20`, for both lists and strings.
- `encode_slice_matches_alloy` sweeps all 256 single-byte strings, the only shape with a special encoding.
- Round-trip and `is_null_ref` tests cover the remainder.

Errors are compared as accept-or-reject rather than by variant: the contract is that invalid input is rejected, not which variant surfaces. On success the tests assert both the decoded value and the buffer advance.

## Benchmark results

Marginal against its own parent, #658, on block 24001988, execute-metered — [#658](https://github.com/axiom-crypto/openvm-eth/actions/runs/30340550900) vs [this PR](https://github.com/axiom-crypto/openvm-eth/actions/runs/30343307761):

| metric | #658 | this PR | delta |
| --- | ---: | ---: | ---: |
| `execute_metered_insns` | 573,518,844 | 560,139,143 | **−13,379,701 (−2.333%)** |
| `metered_rows_unpadded` | 821,986,167 | 805,256,166 | −16,730,001 (−2.035%) |
| `metered_main_cells_unpadded` | 42,655,380,312 | 42,160,281,907 | −495,098,405 (−1.161%) |
| `metered_interaction_cells_unpadded` | 12,920,344,836 | 12,680,532,190 | −239,812,646 (−1.856%) |
| `metered_memory_unpadded_bytes` | 705,340,794,254 | 697,234,594,891 | −8,106,199,363 (−1.149%) |
| app segments | 63 | 62 | **−1** |

Cumulative for the chain (#647 + #658 + this PR) against `develop-v2.1.0`:

| metric | block 24001988 | block 24002549 |
| --- | ---: | ---: |
| `execute_metered_insns` | 588,618,511 → 560,139,143 (**−4.838%**) | 527,179,427 → 501,891,666 (**−4.797%**) |
| `metered_rows_unpadded` | −4.598% | −4.240% |
| `metered_main_cells_unpadded` | −2.543% | −2.336% |
| `metered_interaction_cells_unpadded` | −3.895% | −3.830% |
| `metered_memory_unpadded_bytes` | −2.343% | −1.955% |
| app segments | 65 → 62 (**−3**) | 59 → 57 (**−2**) |

Runs: block 24001988 [`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30335074031) / [chain](https://github.com/axiom-crypto/openvm-eth/actions/runs/30343307761); block 24002549 [`develop-v2.1.0`](https://github.com/axiom-crypto/openvm-eth/actions/runs/30342761467) / [chain](https://github.com/axiom-crypto/openvm-eth/actions/runs/30343329165).

## Notes

`decode_node_header` and `decode_rlp_item` keep `alloy_rlp` as the fallback for anything uncommon, so behaviour is unchanged and only the common paths get shorter.

The unresolved-node fast path compares the witness digest against the parent's expected reference with `digest_eq`, whose length is fixed at compile time so the comparison stays inline as whole-word loads. That comparison is the single hottest operation the fast path performs — a slice comparison of runtime length here costs more than the generic header decode the fast path exists to avoid.
