### PR TITLE
refactor(revm-crypto): recover k256 signers through one helper

### DIFF
--- a/crates/revm-crypto/src/lib.rs
+++ b/crates/revm-crypto/src/lib.rs
@@ -51,6 +51,34 @@ const BN_G2_LEN: usize = 128;
 /// This is an element in the scalar field of BN254.
 const BN_SCALAR_LEN: usize = 32;
 
+/// Recovers a signer's public key hash from a signature over a prehashed message.
+///
+/// The signer's address is the low 20 bytes of the hash. Returning the hash rather than the
+/// address lets each caller build the output shape it needs — a 20-byte `Address` or a 32-byte
+/// left-padded precompile word — with a single copy. `None` covers a malformed signature, a
+/// malformed recovery id, and an unrecoverable key; each caller maps it to its own error type, so
+/// no error value is constructed here.
+#[inline(always)]
+fn recovered_pubkey_hash(sig: &[u8], mut recid: u8, msg_hash: &[u8; 32]) -> Option<[u8; 32]> {
+    let mut signature = Signature::from_slice(sig).ok()?;
+
+    // A signature with a high `s` is normalized to its low-`s` equivalent, which flips the parity
+    // the recovery id encodes.
+    if let Some(normalized) = signature.normalize_s() {
+        signature = normalized;
+        recid ^= 1;
+    }
+
+    let recovery_id = RecoveryId::from_byte(recid)?;
+    let recovered_key =
+        VerifyingKey::recover_from_prehash_noverify(msg_hash, &signature.to_bytes(), recovery_id)
+            .ok()?;
+
+    // The address is derived from the uncompressed SEC1 encoding without its 0x04 prefix.
+    let public_key = recovered_key.to_encoded_point(false);
+    Some(keccak256(&public_key.as_bytes()[1..65]))
+}
+
 /// OpenVM k256 backend for Alloy crypto operations (transaction validation)
 #[derive(Debug, Default)]
 struct OpenVmK256Provider;
@@ -61,34 +89,10 @@ impl CryptoProvider for OpenVmK256Provider {
         sig: &[u8; 65],
         msg: &[u8; 32],
     ) -> Result<Address, RecoveryError> {
-        // Extract components: sig[0..32]=r, sig[32..64]=s, sig[64]=recovery_id
-        // Parse signature using OpenVM k256
-        let mut signature = Signature::from_slice(&sig[..64]).map_err(|_| RecoveryError::new())?;
-
-        // Normalize signature if needed
-        let mut recid = sig[64];
-        if let Some(sig_normalized) = signature.normalize_s() {
-            signature = sig_normalized;
-            recid ^= 1;
-        }
-
-        // Create recovery ID
-        let recovery_id = RecoveryId::from_byte(recid).ok_or(RecoveryError::new())?;
-
-        // Recover public key using OpenVM
-        let recovered_key =
-            VerifyingKey::recover_from_prehash_noverify(msg, &signature.to_bytes(), recovery_id)
-                .map_err(|_| RecoveryError::new())?;
-
-        // Hash the uncompressed SEC1 key without the 0x04 prefix.
-        let public_key = recovered_key.to_encoded_point(false);
-        let encoded_pubkey = &public_key.as_bytes()[1..65];
-
-        // Hash to get Ethereum address
-        let pubkey_hash = keccak256(encoded_pubkey);
-        let address_bytes = &pubkey_hash[12..32]; // Last 20 bytes
-
-        Ok(Address::from_slice(address_bytes))
+        // sig[0..32]=r, sig[32..64]=s, sig[64]=recovery_id
+        let pubkey_hash =
+            recovered_pubkey_hash(&sig[..64], sig[64], msg).ok_or_else(RecoveryError::new)?;
+        Ok(Address::from_slice(&pubkey_hash[12..32]))
     }
 
     fn verify_and_compute_signer_unchecked(
@@ -272,28 +276,12 @@ impl Crypto for OpenVmCrypto {
     fn secp256k1_ecrecover(
         &self,
         sig_bytes: &[u8; 64],
-        mut recid: u8,
+        recid: u8,
         msg_hash: &[u8; 32],
     ) -> Result<[u8; 32], PrecompileHalt> {
-        let mut sig = Signature::from_slice(sig_bytes)
-            .map_err(|_| PrecompileHalt::other("Invalid signature format"))?;
+        let pubkey_hash = recovered_pubkey_hash(sig_bytes, recid, msg_hash)
+            .ok_or_else(|| PrecompileHalt::other("secp256k1 signature recovery failed"))?;
 
-        if let Some(sig_normalized) = sig.normalize_s() {
-            sig = sig_normalized;
-            recid ^= 1;
-        }
-
-        let recovery_id = RecoveryId::from_byte(recid)
-            .ok_or_else(|| PrecompileHalt::other("Invalid recovery ID"))?;
-
-        let recovered_key =
-            VerifyingKey::recover_from_prehash_noverify(msg_hash, &sig.to_bytes(), recovery_id)
-                .map_err(|_| PrecompileHalt::other("Key recovery failed"))?;
-
-        let public_key = recovered_key.to_encoded_point(false);
-        let encoded_pubkey = &public_key.as_bytes()[1..65];
-
-        let pubkey_hash = keccak256(encoded_pubkey);
         let mut address = [0u8; 32];
         address[12..].copy_from_slice(&pubkey_hash[12..]);
 


### PR DESCRIPTION
Both the Alloy signer-recovery provider and the ecrecover precompile ran the same parse / normalize / recover / hash sequence. They now share one inlined helper.

The helper returns the recovered public key hash rather than an address, so each caller shapes the output it needs — a 20-byte `Address`, or a 32-byte left-padded precompile word — with a single copy. This matters: an earlier attempt at the same dedup returned an intermediate `[u8; 20]`, which turned the precompile's `address[12..].copy_from_slice(..)` into an outlined `memcpy` and was reverted for it. Returning the hash avoids the intermediate entirely; emitted code for the two entry points totals 37 instructions less than the duplicated version it replaces.

The three distinct `PrecompileHalt` messages collapse into one because revm discards the error — `crypto().secp256k1_ecrecover(..).ok()` maps any failure to empty output, so the specific message was never observable.

Measured on block 24001988, execute-metered, against `develop-v2.1.0` @ 112b159c:

| | insns | segments | rows |
|---|---|---|---|
| base | 588,618,511 | 65 | 844,070,559 |
| this PR | 588,619,792 (+0.00022%) | 65 | 844,068,150 (−2,409) |

The cost is +1,281 instructions over the whole block, which is roughly +4 per transaction — signature recovery runs once per transaction. Segment count is unchanged and rows are marginally lower. Two runs of the base commit produced bit-identical counters, so this delta is signal rather than run-to-run variance.

Worth knowing for review: neither entry point has host-runnable test coverage, and neither can have any. OpenVM's k256 `moduli_declare!` expands to `todo!()` off-target, so even `Signature::from_slice` panics natively. Both functions are currently exercised only by end-to-end block execution.
