### PR TITLE
feat: standard C interface for BLAKE2 compression function

### DIFF
--- a/crates/accelerators/src/ffi/blake2.rs
+++ b/crates/accelerators/src/ffi/blake2.rs
@@ -1,0 +1,35 @@
+//! C ABI for the BLAKE2 compression function.
+
+use crate::{
+    ops,
+    types::{ZkvmBlake2fMessage, ZkvmBlake2fOffset, ZkvmBlake2fState, ZkvmStatus},
+};
+
+/// Apply the BLAKE2 compression function F (EIP-152) to `h` in place.
+///
+/// Returns [`ZkvmStatus::Fail`] if any pointer is NULL, or if `f` is neither
+/// 0 nor 1.
+///
+/// # Safety
+///
+/// - `h`, if non-NULL, must be valid for reads and writes of 64 bytes.
+/// - `m`, if non-NULL, must be valid for reads of 128 bytes.
+/// - `t`, if non-NULL, must be valid for reads of 16 bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zkvm_blake2f(
+    rounds: u32,
+    h: *mut ZkvmBlake2fState,
+    m: *const ZkvmBlake2fMessage,
+    t: *const ZkvmBlake2fOffset,
+    f: u8,
+) -> ZkvmStatus {
+    if h.is_null() || m.is_null() || t.is_null() {
+        return ZkvmStatus::Fail;
+    }
+    // SAFETY: non-NULL checked above; validity is guaranteed by the caller.
+    let (h, m, t) = unsafe { (&mut *h, &*m, &*t) };
+    match ops::blake2f(rounds, h, m, t, f) {
+        Ok(()) => ZkvmStatus::Ok,
+        Err(_) => ZkvmStatus::Fail,
+    }
+}

--- a/crates/accelerators/src/ffi/mod.rs
+++ b/crates/accelerators/src/ffi/mod.rs
@@ -4,6 +4,8 @@
 //! converts them to references, calls the operation, and maps the result to
 //! [`crate::types::ZkvmStatus`]. No other logic lives here.
 
+mod blake2;
 mod hash;
 
+pub use blake2::*;
 pub use hash::*;

--- a/crates/accelerators/src/ops/blake2/mod.rs
+++ b/crates/accelerators/src/ops/blake2/mod.rs
@@ -1,0 +1,77 @@
+//! BLAKE2b compression function F (EIP-152).
+//!
+//! Vendored from revm-precompile, which adapted the compression function from
+//! [`blake2b_simd`](https://github.com/oconnor663/blake2_simd) (MIT license)
+//! for EIP-152 variable round counts.
+
+mod portable;
+
+use crate::{
+    ops::Error,
+    types::{ZkvmBlake2fMessage, ZkvmBlake2fOffset, ZkvmBlake2fState},
+};
+
+type Word = u64;
+
+const IV: [Word; 8] = [
+    0x6A09E667F3BCC908,
+    0xBB67AE8584CAA73B,
+    0x3C6EF372FE94F82B,
+    0xA54FF53A5F1D36F1,
+    0x510E527FADE682D1,
+    0x9B05688C2B3E6C1F,
+    0x1F83D9ABFB41BD6B,
+    0x5BE0CD19137E2179,
+];
+
+// SIGMA has spec period 10 (RFC 7693 §2.7). BLAKE2b runs 12 rounds by reusing
+// SIGMA[0]/SIGMA[1] for rounds 10/11; for EIP-152's variable round count we
+// must index with `r % 10`, not `r % 12`.
+const SIGMA: [[u8; 16]; 10] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+    [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+    [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+    [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+    [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+    [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+    [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+    [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+    [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+];
+
+/// Apply the BLAKE2 compression function F to the state vector `h` in place.
+///
+/// `h`, `m` and `t` hold little-endian words; `f` is the final-block
+/// indicator and must be `0` or `1`.
+pub fn blake2f(
+    rounds: u32,
+    h: &mut ZkvmBlake2fState,
+    m: &ZkvmBlake2fMessage,
+    t: &ZkvmBlake2fOffset,
+    f: u8,
+) -> Result<(), Error> {
+    if f > 1 {
+        return Err(Error::InvalidFinalFlag);
+    }
+
+    let mut state = [0u64; 8];
+    for (word, chunk) in state.iter_mut().zip(h.data.chunks_exact(8)) {
+        *word = u64::from_le_bytes(chunk.try_into().unwrap());
+    }
+    let mut message = [0u64; 16];
+    for (word, chunk) in message.iter_mut().zip(m.data.chunks_exact(8)) {
+        *word = u64::from_le_bytes(chunk.try_into().unwrap());
+    }
+    let offset = [
+        u64::from_le_bytes(t.data[..8].try_into().unwrap()),
+        u64::from_le_bytes(t.data[8..].try_into().unwrap()),
+    ];
+
+    portable::compress(rounds, &mut state, &message, &offset, f == 1);
+
+    for (chunk, word) in h.data.chunks_exact_mut(8).zip(state.iter()) {
+        chunk.copy_from_slice(&word.to_le_bytes());
+    }
+    Ok(())
+}

--- a/crates/accelerators/src/ops/blake2/portable.rs
+++ b/crates/accelerators/src/ops/blake2/portable.rs
@@ -1,0 +1,76 @@
+// Adapted from https://github.com/oconnor663/blake2_simd
+// Copyright (c) 2018 Jack O'Connor
+// Licensed under the MIT license
+
+use super::{Word, IV, SIGMA};
+
+// G is the mixing function, called eight times per round in the compression
+// function. V is the 16-word state vector of the compression function, usually
+// described as a 4x4 matrix. A, B, C, and D are the mixing indices, set by the
+// caller first to the four columns of V, and then to its four diagonals. X and
+// Y are words of input, chosen by the caller according to the message
+// schedule, SIGMA.
+#[inline(always)]
+const fn g(v: &mut [Word; 16], a: usize, b: usize, c: usize, d: usize, x: Word, y: Word) {
+    v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+    v[d] = (v[d] ^ v[a]).rotate_right(32);
+    v[c] = v[c].wrapping_add(v[d]);
+    v[b] = (v[b] ^ v[c]).rotate_right(24);
+    v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+    v[d] = (v[d] ^ v[a]).rotate_right(16);
+    v[c] = v[c].wrapping_add(v[d]);
+    v[b] = (v[b] ^ v[c]).rotate_right(63);
+}
+
+#[inline(always)]
+const fn round(r: usize, m: &[Word; 16], v: &mut [Word; 16]) {
+    // Select the message schedule based on the round.
+    let s = SIGMA[r % 10];
+
+    // Mix the columns.
+    g(v, 0, 4, 8, 12, m[s[0] as usize], m[s[1] as usize]);
+    g(v, 1, 5, 9, 13, m[s[2] as usize], m[s[3] as usize]);
+    g(v, 2, 6, 10, 14, m[s[4] as usize], m[s[5] as usize]);
+    g(v, 3, 7, 11, 15, m[s[6] as usize], m[s[7] as usize]);
+
+    // Mix the rows.
+    g(v, 0, 5, 10, 15, m[s[8] as usize], m[s[9] as usize]);
+    g(v, 1, 6, 11, 12, m[s[10] as usize], m[s[11] as usize]);
+    g(v, 2, 7, 8, 13, m[s[12] as usize], m[s[13] as usize]);
+    g(v, 3, 4, 9, 14, m[s[14] as usize], m[s[15] as usize]);
+}
+
+pub(super) fn compress(rounds: u32, words: &mut [Word; 8], m: &[Word; 16], t: &[Word; 2], f: bool) {
+    // Initialize the compression state.
+    let mut v = [
+        words[0],
+        words[1],
+        words[2],
+        words[3],
+        words[4],
+        words[5],
+        words[6],
+        words[7],
+        IV[0],
+        IV[1],
+        IV[2],
+        IV[3],
+        IV[4] ^ t[0],
+        IV[5] ^ t[1],
+        IV[6] ^ if f { !0 } else { 0 },
+        IV[7],
+    ];
+
+    for i in 0..rounds as usize {
+        round(i, m, &mut v);
+    }
+
+    words[0] ^= v[0] ^ v[8];
+    words[1] ^= v[1] ^ v[9];
+    words[2] ^= v[2] ^ v[10];
+    words[3] ^= v[3] ^ v[11];
+    words[4] ^= v[4] ^ v[12];
+    words[5] ^= v[5] ^ v[13];
+    words[6] ^= v[6] ^ v[14];
+    words[7] ^= v[7] ^ v[15];
+}

--- a/crates/accelerators/src/ops/mod.rs
+++ b/crates/accelerators/src/ops/mod.rs
@@ -4,8 +4,10 @@
 //! G2 is `x_c0 || x_c1 || y_c0 || y_c1`, BN254 G2 uses the EIP-197
 //! `x_c1 || x_c0 || y_c1 || y_c0` order.
 
+mod blake2;
 mod hash;
 
+pub use blake2::blake2f;
 pub use hash::{keccak256, ripemd160, sha256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16,6 +18,8 @@ pub enum Error {
     PointNotOnCurve,
     /// A point is on the curve but not in the prime-order subgroup.
     PointNotInSubgroup,
+    /// The BLAKE2f final-block flag is neither 0 nor 1.
+    InvalidFinalFlag,
     /// A signature could not be parsed or key recovery failed.
     InvalidSignature,
     /// KZG commitment/proof/field-element inputs are malformed.

--- a/crates/accelerators/tests/conformance/blake2.rs
+++ b/crates/accelerators/tests/conformance/blake2.rs
@@ -2,8 +2,9 @@
 
 use hex_literal::hex;
 use openvm_accelerators::{
+    ffi::zkvm_blake2f,
     ops::{blake2f, Error},
-    types::{ZkvmBlake2fMessage, ZkvmBlake2fOffset, ZkvmBlake2fState},
+    types::{ZkvmBlake2fMessage, ZkvmBlake2fOffset, ZkvmBlake2fState, ZkvmStatus},
 };
 
 /// EIP-152 vectors 4-7 share the same h, m and t inputs.
@@ -79,5 +80,44 @@ fn blake2f_invalid_final_flag() {
     let result = blake2f(12, &mut h, &m(), &ZkvmBlake2fOffset { data: T }, 2);
     assert_eq!(result, Err(Error::InvalidFinalFlag));
     // The state must be untouched on failure.
+    assert_eq!(h.data, H);
+}
+
+#[test]
+fn zkvm_blake2f_smoke() {
+    let mut h = ZkvmBlake2fState { data: H };
+    let m = m();
+    let t = ZkvmBlake2fOffset { data: T };
+
+    let status = unsafe { zkvm_blake2f(12, &mut h, &m, &t, 1) };
+    assert_eq!(status, ZkvmStatus::Ok);
+    assert_eq!(
+        h.data,
+        hex!(
+            "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1"
+            "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923"
+        )
+    );
+
+    // An invalid final flag maps to the failure status.
+    let status = unsafe { zkvm_blake2f(12, &mut h, &m, &t, 2) };
+    assert_eq!(status, ZkvmStatus::Fail);
+}
+
+#[test]
+fn zkvm_blake2f_null_pointers() {
+    let mut h = ZkvmBlake2fState { data: H };
+    let m = m();
+    let t = ZkvmBlake2fOffset { data: T };
+
+    let status = unsafe { zkvm_blake2f(12, core::ptr::null_mut(), &m, &t, 1) };
+    assert_eq!(status, ZkvmStatus::Fail);
+
+    let status = unsafe { zkvm_blake2f(12, &mut h, core::ptr::null(), &t, 1) };
+    assert_eq!(status, ZkvmStatus::Fail);
+
+    let status = unsafe { zkvm_blake2f(12, &mut h, &m, core::ptr::null(), 1) };
+    assert_eq!(status, ZkvmStatus::Fail);
+    // The state must be untouched when a pointer is NULL.
     assert_eq!(h.data, H);
 }

--- a/crates/accelerators/tests/conformance/blake2.rs
+++ b/crates/accelerators/tests/conformance/blake2.rs
@@ -1,0 +1,83 @@
+//! BLAKE2f conformance: the official EIP-152 test vectors 4-7.
+
+use hex_literal::hex;
+use openvm_accelerators::{
+    ops::{blake2f, Error},
+    types::{ZkvmBlake2fMessage, ZkvmBlake2fOffset, ZkvmBlake2fState},
+};
+
+/// EIP-152 vectors 4-7 share the same h, m and t inputs.
+const H: [u8; 64] = hex!(
+    "48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5"
+    "d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b"
+);
+const T: [u8; 16] = hex!("03000000000000000000000000000000");
+
+fn m() -> ZkvmBlake2fMessage {
+    let mut m = ZkvmBlake2fMessage { data: [0; 128] };
+    m.data[..3].copy_from_slice(b"abc");
+    m
+}
+
+fn check(rounds: u32, f: u8, expected: [u8; 64]) {
+    let mut h = ZkvmBlake2fState { data: H };
+    blake2f(rounds, &mut h, &m(), &ZkvmBlake2fOffset { data: T }, f).unwrap();
+    assert_eq!(h.data, expected, "rounds={rounds}, f={f}");
+}
+
+#[test]
+fn blake2f_eip152_vector_4_zero_rounds() {
+    check(
+        0,
+        1,
+        hex!(
+            "08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5"
+            "d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b"
+        ),
+    );
+}
+
+#[test]
+fn blake2f_eip152_vector_5_twelve_rounds() {
+    check(
+        12,
+        1,
+        hex!(
+            "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1"
+            "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923"
+        ),
+    );
+}
+
+#[test]
+fn blake2f_eip152_vector_6_no_final_flag() {
+    check(
+        12,
+        0,
+        hex!(
+            "75ab69d3190a562c51aef8d88f1c2775876944407270c42c9844252c26d28752"
+            "98743e7f6d5ea2f2d3e8d226039cd31b4e426ac4f2d3d666a610c2116fde4735"
+        ),
+    );
+}
+
+#[test]
+fn blake2f_eip152_vector_7_one_round() {
+    check(
+        1,
+        1,
+        hex!(
+            "b63a380cb2897d521994a85234ee2c181b5f844d2c624c002677e9703449d2fb"
+            "a551b3a8333bcdf5f2f7e08993d53923de3d64fcc68c034e717b9293fed7a421"
+        ),
+    );
+}
+
+#[test]
+fn blake2f_invalid_final_flag() {
+    let mut h = ZkvmBlake2fState { data: H };
+    let result = blake2f(12, &mut h, &m(), &ZkvmBlake2fOffset { data: T }, 2);
+    assert_eq!(result, Err(Error::InvalidFinalFlag));
+    // The state must be untouched on failure.
+    assert_eq!(h.data, H);
+}

--- a/crates/accelerators/tests/conformance/main.rs
+++ b/crates/accelerators/tests/conformance/main.rs
@@ -3,4 +3,5 @@
 //!
 //! Modules mirror the `src/ops` layout: one file per domain.
 
+mod blake2;
 mod hash;


### PR DESCRIPTION
Second PR of the zkVM accelerators C interface series: adds the BLAKE2 compression function F. The implementation is based on the official implementation done by `revm-precompile` (reference [link](https://github.com/bluealloy/revm/tree/main/crates/precompile/src/blake2)).

resolves INT-8933