### PR TITLE
feat: standard C Interface for ECDSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6790,6 +6790,7 @@ name = "openvm-accelerators"
 version = "0.4.0"
 dependencies = [
  "hex-literal",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0)",
  "openvm-keccak256",
  "openvm-sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6793,6 +6793,7 @@ dependencies = [
  "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0)",
  "openvm-keccak256",
  "openvm-sha2",
+ "p256 0.13.2 (git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0)",
  "ripemd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6790,6 +6790,7 @@ name = "openvm-accelerators"
 version = "0.4.0"
 dependencies = [
  "hex-literal",
+ "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?branch=develop-v2.1.0)",
  "openvm-keccak256",
  "openvm-sha2",
  "ripemd",

--- a/crates/accelerators/Cargo.toml
+++ b/crates/accelerators/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 # openvm
 openvm-k256.workspace = true
+openvm-p256.workspace = true
 openvm-keccak256.workspace = true
 openvm-sha2.workspace = true
 

--- a/crates/accelerators/Cargo.toml
+++ b/crates/accelerators/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 # openvm
+openvm-k256.workspace = true
 openvm-keccak256.workspace = true
 openvm-sha2.workspace = true
 

--- a/crates/accelerators/Cargo.toml
+++ b/crates/accelerators/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 # openvm
-openvm-k256.workspace = true
 openvm-p256.workspace = true
 openvm-keccak256.workspace = true
 openvm-sha2.workspace = true
@@ -19,8 +18,14 @@ openvm-sha2.workspace = true
 # crypto
 ripemd = { version = "0.1.3", default-features = false }
 
+# The OpenVM-accelerated k256 fork; its ECDSA recovery relies on zkVM hints
+# and is unimplemented outside the guest.
+[target.'cfg(any(target_os = "none", target_os = "openvm"))'.dependencies]
+openvm-k256.workspace = true
+
 # Host implementations when not building for the zkVM guest.
 [target.'cfg(not(any(target_os = "none", target_os = "openvm")))'.dependencies]
+k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 openvm-keccak256 = { workspace = true, features = ["tiny_keccak"] }
 openvm-sha2 = { workspace = true, features = ["import_sha2"] }
 

--- a/crates/accelerators/src/ffi/ecdsa.rs
+++ b/crates/accelerators/src/ffi/ecdsa.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     ops,
-    types::{ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature, ZkvmStatus},
+    types::{
+        ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature, ZkvmSecp256r1Hash,
+        ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature, ZkvmStatus,
+    },
 };
 
 /// Recover the uncompressed secp256k1 public key from an ECDSA signature
@@ -60,6 +63,37 @@ pub unsafe extern "C" fn zkvm_secp256k1_verify(
     // SAFETY: non-NULL checked above; validity is guaranteed by the caller.
     let (msg, sig, pubkey, verified) = unsafe { (&*msg, &*sig, &*pubkey, &mut *verified) };
     match ops::secp256k1_verify(msg, sig, pubkey, verified) {
+        Ok(()) => ZkvmStatus::Ok,
+        Err(_) => ZkvmStatus::Fail,
+    }
+}
+
+/// Verify an ECDSA signature over secp256r1 (P-256) against an uncompressed
+/// public key, writing the result to `verified`.
+///
+/// Returns [`ZkvmStatus::Fail`] if any pointer is NULL or the inputs are
+/// malformed; `verified` is `false` when a well-formed signature does not
+/// verify.
+///
+/// # Safety
+///
+/// - `msg`, if non-NULL, must be valid for reads of 32 bytes.
+/// - `sig`, if non-NULL, must be valid for reads of 64 bytes.
+/// - `pubkey`, if non-NULL, must be valid for reads of 64 bytes.
+/// - `verified`, if non-NULL, must be valid for writes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zkvm_secp256r1_verify(
+    msg: *const ZkvmSecp256r1Hash,
+    sig: *const ZkvmSecp256r1Signature,
+    pubkey: *const ZkvmSecp256r1Pubkey,
+    verified: *mut bool,
+) -> ZkvmStatus {
+    if msg.is_null() || sig.is_null() || pubkey.is_null() || verified.is_null() {
+        return ZkvmStatus::Fail;
+    }
+    // SAFETY: non-NULL checked above; validity is guaranteed by the caller.
+    let (msg, sig, pubkey, verified) = unsafe { (&*msg, &*sig, &*pubkey, &mut *verified) };
+    match ops::secp256r1_verify(msg, sig, pubkey, verified) {
         Ok(()) => ZkvmStatus::Ok,
         Err(_) => ZkvmStatus::Fail,
     }

--- a/crates/accelerators/src/ffi/ecdsa.rs
+++ b/crates/accelerators/src/ffi/ecdsa.rs
@@ -1,0 +1,66 @@
+//! C ABI for the ECDSA accelerators.
+
+use crate::{
+    ops,
+    types::{ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature, ZkvmStatus},
+};
+
+/// Recover the uncompressed secp256k1 public key from an ECDSA signature
+/// over `msg` into `output`.
+///
+/// Returns [`ZkvmStatus::Fail`] if any pointer is NULL, the signature cannot
+/// be parsed, or the recovery id is invalid.
+///
+/// # Safety
+///
+/// - `msg`, if non-NULL, must be valid for reads of 32 bytes.
+/// - `sig`, if non-NULL, must be valid for reads of 64 bytes.
+/// - `output`, if non-NULL, must be valid for writes of 64 bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zkvm_secp256k1_ecrecover(
+    msg: *const ZkvmSecp256k1Hash,
+    sig: *const ZkvmSecp256k1Signature,
+    recid: u8,
+    output: *mut ZkvmSecp256k1Pubkey,
+) -> ZkvmStatus {
+    if msg.is_null() || sig.is_null() || output.is_null() {
+        return ZkvmStatus::Fail;
+    }
+    // SAFETY: non-NULL checked above; validity is guaranteed by the caller.
+    let (msg, sig, output) = unsafe { (&*msg, &*sig, &mut *output) };
+    match ops::secp256k1_ecrecover(msg, sig, recid, output) {
+        Ok(()) => ZkvmStatus::Ok,
+        Err(_) => ZkvmStatus::Fail,
+    }
+}
+
+/// Verify an ECDSA signature over secp256k1 against an uncompressed public
+/// key, writing the result to `verified`.
+///
+/// Returns [`ZkvmStatus::Fail`] if any pointer is NULL or the inputs are
+/// malformed; `verified` is `false` when a well-formed signature does not
+/// verify.
+///
+/// # Safety
+///
+/// - `msg`, if non-NULL, must be valid for reads of 32 bytes.
+/// - `sig`, if non-NULL, must be valid for reads of 64 bytes.
+/// - `pubkey`, if non-NULL, must be valid for reads of 64 bytes.
+/// - `verified`, if non-NULL, must be valid for writes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zkvm_secp256k1_verify(
+    msg: *const ZkvmSecp256k1Hash,
+    sig: *const ZkvmSecp256k1Signature,
+    pubkey: *const ZkvmSecp256k1Pubkey,
+    verified: *mut bool,
+) -> ZkvmStatus {
+    if msg.is_null() || sig.is_null() || pubkey.is_null() || verified.is_null() {
+        return ZkvmStatus::Fail;
+    }
+    // SAFETY: non-NULL checked above; validity is guaranteed by the caller.
+    let (msg, sig, pubkey, verified) = unsafe { (&*msg, &*sig, &*pubkey, &mut *verified) };
+    match ops::secp256k1_verify(msg, sig, pubkey, verified) {
+        Ok(()) => ZkvmStatus::Ok,
+        Err(_) => ZkvmStatus::Fail,
+    }
+}

--- a/crates/accelerators/src/ffi/mod.rs
+++ b/crates/accelerators/src/ffi/mod.rs
@@ -5,7 +5,9 @@
 //! [`crate::types::ZkvmStatus`]. No other logic lives here.
 
 mod blake2;
+mod ecdsa;
 mod hash;
 
 pub use blake2::*;
+pub use ecdsa::*;
 pub use hash::*;

--- a/crates/accelerators/src/ops/ecdsa.rs
+++ b/crates/accelerators/src/ops/ecdsa.rs
@@ -1,6 +1,9 @@
 //! ECDSA operations.
 
-use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
+#[cfg(any(target_os = "none", target_os = "openvm"))]
+use openvm_k256 as k256;
+
+use k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
 
 use crate::{
     ops::Error,
@@ -29,9 +32,13 @@ pub fn secp256k1_ecrecover(
     }
     let recovery_id = RecoveryId::from_byte(recid).ok_or(Error::InvalidSignature)?;
 
+    #[cfg(any(target_os = "none", target_os = "openvm"))]
     let key =
         VerifyingKey::recover_from_prehash_noverify(&msg.data, &signature.to_bytes(), recovery_id)
             .map_err(|_| Error::InvalidSignature)?;
+    #[cfg(not(any(target_os = "none", target_os = "openvm")))]
+    let key = VerifyingKey::recover_from_prehash(&msg.data, &signature, recovery_id)
+        .map_err(|_| Error::InvalidSignature)?;
 
     let point = key.to_encoded_point(false);
     output.data.copy_from_slice(&point.as_bytes()[1..65]);

--- a/crates/accelerators/src/ops/ecdsa.rs
+++ b/crates/accelerators/src/ops/ecdsa.rs
@@ -1,0 +1,61 @@
+//! ECDSA operations.
+
+use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, VerifyingKey};
+
+use crate::{
+    ops::Error,
+    types::{ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature},
+};
+
+/// Recover the uncompressed secp256k1 public key from an ECDSA signature
+/// over `msg` into `output`.
+///
+/// Both low-s and high-s signatures are accepted.
+pub fn secp256k1_ecrecover(
+    msg: &ZkvmSecp256k1Hash,
+    sig: &ZkvmSecp256k1Signature,
+    mut recid: u8,
+    output: &mut ZkvmSecp256k1Pubkey,
+) -> Result<(), Error> {
+    let mut signature = Signature::from_slice(&sig.data).map_err(|_| Error::InvalidSignature)?;
+    // k256 requires a low-s signature for recovery; normalizing flips the
+    // recovery id parity but recovers the same key.
+    if let Some(normalized) = signature.normalize_s() {
+        signature = normalized;
+        recid ^= 1;
+    }
+    let recovery_id = RecoveryId::from_byte(recid).ok_or(Error::InvalidSignature)?;
+
+    let key =
+        VerifyingKey::recover_from_prehash_noverify(&msg.data, &signature.to_bytes(), recovery_id)
+            .map_err(|_| Error::InvalidSignature)?;
+
+    let point = key.to_encoded_point(false);
+    output.data.copy_from_slice(&point.as_bytes()[1..65]);
+    Ok(())
+}
+
+/// Verify an ECDSA signature over secp256k1 against an uncompressed public
+/// key, writing the result to `verified`.
+///
+/// Both low-s and high-s signatures are accepted.
+pub fn secp256k1_verify(
+    msg: &ZkvmSecp256k1Hash,
+    sig: &ZkvmSecp256k1Signature,
+    pubkey: &ZkvmSecp256k1Pubkey,
+    verified: &mut bool,
+) -> Result<(), Error> {
+    *verified = false;
+
+    let mut sec1 = [0u8; 65];
+    sec1[0] = 0x04;
+    sec1[1..].copy_from_slice(&pubkey.data);
+    let key = VerifyingKey::from_sec1_bytes(&sec1).map_err(|_| Error::PointNotOnCurve)?;
+    let mut signature = Signature::from_slice(&sig.data).map_err(|_| Error::InvalidSignature)?;
+    // k256 rejects high-s signatures in verification. Normalize to accept both forms.
+    if let Some(normalized) = signature.normalize_s() {
+        signature = normalized;
+    }
+    *verified = key.verify_prehash(&msg.data, &signature).is_ok();
+    Ok(())
+}

--- a/crates/accelerators/src/ops/ecdsa.rs
+++ b/crates/accelerators/src/ops/ecdsa.rs
@@ -4,7 +4,10 @@ use openvm_k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signatu
 
 use crate::{
     ops::Error,
-    types::{ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature},
+    types::{
+        ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature, ZkvmSecp256r1Hash,
+        ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature,
+    },
 };
 
 /// Recover the uncompressed secp256k1 public key from an ECDSA signature
@@ -56,6 +59,29 @@ pub fn secp256k1_verify(
     if let Some(normalized) = signature.normalize_s() {
         signature = normalized;
     }
+    *verified = key.verify_prehash(&msg.data, &signature).is_ok();
+    Ok(())
+}
+
+/// Verify an ECDSA signature over secp256r1 (P-256) against an uncompressed
+/// public key, writing the result to `verified`.
+pub fn secp256r1_verify(
+    msg: &ZkvmSecp256r1Hash,
+    sig: &ZkvmSecp256r1Signature,
+    pubkey: &ZkvmSecp256r1Pubkey,
+    verified: &mut bool,
+) -> Result<(), Error> {
+    use openvm_p256::{
+        ecdsa::{Signature, VerifyingKey},
+        EncodedPoint,
+    };
+
+    *verified = false;
+
+    let encoded_point = EncodedPoint::from_untagged_bytes(&pubkey.data.into());
+    let key =
+        VerifyingKey::from_encoded_point(&encoded_point).map_err(|_| Error::PointNotOnCurve)?;
+    let signature = Signature::from_slice(&sig.data).map_err(|_| Error::InvalidSignature)?;
     *verified = key.verify_prehash(&msg.data, &signature).is_ok();
     Ok(())
 }

--- a/crates/accelerators/src/ops/ecdsa/mod.rs
+++ b/crates/accelerators/src/ops/ecdsa/mod.rs
@@ -1,0 +1,10 @@
+//! ECDSA operations.
+//!
+//! Split by curve: the two crates providing them use the same type names, and
+//! secp256k1 additionally needs a guest/host split that secp256r1 does not.
+
+mod secp256k1;
+mod secp256r1;
+
+pub use secp256k1::{secp256k1_ecrecover, secp256k1_verify};
+pub use secp256r1::secp256r1_verify;

--- a/crates/accelerators/src/ops/ecdsa/secp256k1.rs
+++ b/crates/accelerators/src/ops/ecdsa/secp256k1.rs
@@ -1,5 +1,8 @@
-//! ECDSA operations.
+//! ECDSA over the secp256k1 curve.
 
+// In the guest, secp256k1 operations use the OpenVM-accelerated k256; on
+// the host they use upstream RustCrypto k256 (the ECDSA recovery
+// relies on zkVM hints and is unimplemented outside the guest).
 #[cfg(any(target_os = "none", target_os = "openvm"))]
 use openvm_k256 as k256;
 
@@ -7,10 +10,7 @@ use k256::ecdsa::{signature::hazmat::PrehashVerifier, RecoveryId, Signature, Ver
 
 use crate::{
     ops::Error,
-    types::{
-        ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature, ZkvmSecp256r1Hash,
-        ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature,
-    },
+    types::{ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature},
 };
 
 /// Recover the uncompressed secp256k1 public key from an ECDSA signature
@@ -66,29 +66,6 @@ pub fn secp256k1_verify(
     if let Some(normalized) = signature.normalize_s() {
         signature = normalized;
     }
-    *verified = key.verify_prehash(&msg.data, &signature).is_ok();
-    Ok(())
-}
-
-/// Verify an ECDSA signature over secp256r1 (P-256) against an uncompressed
-/// public key, writing the result to `verified`.
-pub fn secp256r1_verify(
-    msg: &ZkvmSecp256r1Hash,
-    sig: &ZkvmSecp256r1Signature,
-    pubkey: &ZkvmSecp256r1Pubkey,
-    verified: &mut bool,
-) -> Result<(), Error> {
-    use openvm_p256::{
-        ecdsa::{Signature, VerifyingKey},
-        EncodedPoint,
-    };
-
-    *verified = false;
-
-    let encoded_point = EncodedPoint::from_untagged_bytes(&pubkey.data.into());
-    let key =
-        VerifyingKey::from_encoded_point(&encoded_point).map_err(|_| Error::PointNotOnCurve)?;
-    let signature = Signature::from_slice(&sig.data).map_err(|_| Error::InvalidSignature)?;
     *verified = key.verify_prehash(&msg.data, &signature).is_ok();
     Ok(())
 }

--- a/crates/accelerators/src/ops/ecdsa/secp256r1.rs
+++ b/crates/accelerators/src/ops/ecdsa/secp256r1.rs
@@ -1,0 +1,29 @@
+//! ECDSA over the secp256r1 (P-256) curve.
+
+use openvm_p256::{
+    ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey},
+    EncodedPoint,
+};
+
+use crate::{
+    ops::Error,
+    types::{ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature},
+};
+
+/// Verify an ECDSA signature over secp256r1 (P-256) against an uncompressed
+/// public key, writing the result to `verified`.
+pub fn secp256r1_verify(
+    msg: &ZkvmSecp256r1Hash,
+    sig: &ZkvmSecp256r1Signature,
+    pubkey: &ZkvmSecp256r1Pubkey,
+    verified: &mut bool,
+) -> Result<(), Error> {
+    *verified = false;
+
+    let encoded_point = EncodedPoint::from_untagged_bytes(&pubkey.data.into());
+    let key =
+        VerifyingKey::from_encoded_point(&encoded_point).map_err(|_| Error::PointNotOnCurve)?;
+    let signature = Signature::from_slice(&sig.data).map_err(|_| Error::InvalidSignature)?;
+    *verified = key.verify_prehash(&msg.data, &signature).is_ok();
+    Ok(())
+}

--- a/crates/accelerators/src/ops/mod.rs
+++ b/crates/accelerators/src/ops/mod.rs
@@ -9,7 +9,7 @@ mod ecdsa;
 mod hash;
 
 pub use blake2::blake2f;
-pub use ecdsa::{secp256k1_ecrecover, secp256k1_verify};
+pub use ecdsa::{secp256k1_ecrecover, secp256k1_verify, secp256r1_verify};
 pub use hash::{keccak256, ripemd160, sha256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/accelerators/src/ops/mod.rs
+++ b/crates/accelerators/src/ops/mod.rs
@@ -5,9 +5,11 @@
 //! `x_c1 || x_c0 || y_c1 || y_c0` order.
 
 mod blake2;
+mod ecdsa;
 mod hash;
 
 pub use blake2::blake2f;
+pub use ecdsa::{secp256k1_ecrecover, secp256k1_verify};
 pub use hash::{keccak256, ripemd160, sha256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/accelerators/tests/conformance/ecdsa.rs
+++ b/crates/accelerators/tests/conformance/ecdsa.rs
@@ -5,8 +5,11 @@
 use hex_literal::hex;
 use openvm_accelerators::{
     ffi::zkvm_secp256r1_verify,
-    ops::{secp256r1_verify, Error},
-    types::{ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature, ZkvmStatus},
+    ops::{keccak256, secp256k1_ecrecover, secp256k1_verify, secp256r1_verify, Error},
+    types::{
+        ZkvmKeccak256Hash, ZkvmSecp256k1Hash, ZkvmSecp256k1Pubkey, ZkvmSecp256k1Signature,
+        ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature, ZkvmStatus,
+    },
 };
 
 /// Splits a 160-byte P256VERIFY input (msg || sig || pk) into its parts.
@@ -92,4 +95,64 @@ fn zkvm_secp256r1_verify_null_pointers() {
 
     let status = unsafe { zkvm_secp256r1_verify(&msg, &sig, &pubkey, core::ptr::null_mut()) };
     assert_eq!(status, ZkvmStatus::Fail);
+}
+
+const K1_MSG: ZkvmSecp256k1Hash = ZkvmSecp256k1Hash {
+    data: hex!("456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"),
+};
+const K1_SIG: ZkvmSecp256k1Signature = ZkvmSecp256k1Signature {
+    data: hex!(
+        "9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608"
+        "4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada"
+    ),
+};
+const K1_ADDRESS: [u8; 20] = hex!("7156526fbd7a3c72969b54f64e42c10fbb768c8a");
+
+#[test]
+fn secp256k1_ecrecover_vector() {
+    let mut pubkey = ZkvmSecp256k1Pubkey { data: [0; 64] };
+    secp256k1_ecrecover(&K1_MSG, &K1_SIG, 1, &mut pubkey).unwrap();
+
+    // The Ethereum address is keccak(pubkey)[12..], derived here exactly as
+    // a caller of the interface would.
+    let mut hash = ZkvmKeccak256Hash { data: [0; 32] };
+    keccak256(&pubkey.data, &mut hash);
+    assert_eq!(hash.data[12..], K1_ADDRESS);
+}
+
+#[test]
+fn secp256k1_ecrecover_invalid_inputs() {
+    let mut pubkey = ZkvmSecp256k1Pubkey { data: [0; 64] };
+
+    // Recovery ids above 3 are invalid.
+    let result = secp256k1_ecrecover(&K1_MSG, &K1_SIG, 4, &mut pubkey);
+    assert_eq!(result, Err(Error::InvalidSignature));
+
+    // The zero signature cannot be parsed.
+    let zero_sig = ZkvmSecp256k1Signature { data: [0; 64] };
+    let result = secp256k1_ecrecover(&K1_MSG, &zero_sig, 0, &mut pubkey);
+    assert_eq!(result, Err(Error::InvalidSignature));
+}
+
+#[test]
+fn secp256k1_verify_roundtrip() {
+    let mut pubkey = ZkvmSecp256k1Pubkey { data: [0; 64] };
+    secp256k1_ecrecover(&K1_MSG, &K1_SIG, 1, &mut pubkey).unwrap();
+
+    let mut verified = false;
+    secp256k1_verify(&K1_MSG, &K1_SIG, &pubkey, &mut verified).unwrap();
+    assert!(verified);
+
+    // Wrong message must not verify; `verified` must be overwritten.
+    let mut wrong_msg = K1_MSG;
+    wrong_msg.data[0] ^= 1;
+    secp256k1_verify(&wrong_msg, &K1_SIG, &pubkey, &mut verified).unwrap();
+    assert!(!verified);
+
+    // A public key that is not on the curve cannot be parsed.
+    verified = true;
+    let bad_pubkey = ZkvmSecp256k1Pubkey { data: [0xff; 64] };
+    let result = secp256k1_verify(&K1_MSG, &K1_SIG, &bad_pubkey, &mut verified);
+    assert_eq!(result, Err(Error::PointNotOnCurve));
+    assert!(!verified);
 }

--- a/crates/accelerators/tests/conformance/ecdsa.rs
+++ b/crates/accelerators/tests/conformance/ecdsa.rs
@@ -4,8 +4,9 @@
 
 use hex_literal::hex;
 use openvm_accelerators::{
+    ffi::zkvm_secp256r1_verify,
     ops::{secp256r1_verify, Error},
-    types::{ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature},
+    types::{ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature, ZkvmStatus},
 };
 
 /// Splits a 160-byte P256VERIFY input (msg || sig || pk) into its parts.
@@ -57,4 +58,38 @@ fn secp256r1_verify_malformed_inputs() {
     let result = secp256r1_verify(&msg, &sig, &bad_pubkey, &mut verified);
     assert_eq!(result, Err(Error::PointNotOnCurve));
     assert!(!verified);
+}
+
+#[test]
+fn zkvm_secp256r1_verify_smoke() {
+    let (msg, sig, pubkey) = parts(&VALID);
+    let mut verified = false;
+
+    let status = unsafe { zkvm_secp256r1_verify(&msg, &sig, &pubkey, &mut verified) };
+    assert_eq!(status, ZkvmStatus::Ok);
+    assert!(verified);
+
+    // Malformed inputs map to the failure status.
+    let bad_pubkey = ZkvmSecp256r1Pubkey { data: [0; 64] };
+    let status = unsafe { zkvm_secp256r1_verify(&msg, &sig, &bad_pubkey, &mut verified) };
+    assert_eq!(status, ZkvmStatus::Fail);
+    assert!(!verified);
+}
+
+#[test]
+fn zkvm_secp256r1_verify_null_pointers() {
+    let (msg, sig, pubkey) = parts(&VALID);
+    let mut verified = false;
+
+    let status = unsafe { zkvm_secp256r1_verify(core::ptr::null(), &sig, &pubkey, &mut verified) };
+    assert_eq!(status, ZkvmStatus::Fail);
+
+    let status = unsafe { zkvm_secp256r1_verify(&msg, core::ptr::null(), &pubkey, &mut verified) };
+    assert_eq!(status, ZkvmStatus::Fail);
+
+    let status = unsafe { zkvm_secp256r1_verify(&msg, &sig, core::ptr::null(), &mut verified) };
+    assert_eq!(status, ZkvmStatus::Fail);
+
+    let status = unsafe { zkvm_secp256r1_verify(&msg, &sig, &pubkey, core::ptr::null_mut()) };
+    assert_eq!(status, ZkvmStatus::Fail);
 }

--- a/crates/accelerators/tests/conformance/ecdsa.rs
+++ b/crates/accelerators/tests/conformance/ecdsa.rs
@@ -1,0 +1,60 @@
+//! ECDSA conformance vectors.
+//!
+//! Tested with vectors from https://github.com/daimo-eth/p256-verifier/tree/master/test-vectors.
+
+use hex_literal::hex;
+use openvm_accelerators::{
+    ops::{secp256r1_verify, Error},
+    types::{ZkvmSecp256r1Hash, ZkvmSecp256r1Pubkey, ZkvmSecp256r1Signature},
+};
+
+/// Splits a 160-byte P256VERIFY input (msg || sig || pk) into its parts.
+fn parts(input: &[u8; 160]) -> (ZkvmSecp256r1Hash, ZkvmSecp256r1Signature, ZkvmSecp256r1Pubkey) {
+    (
+        ZkvmSecp256r1Hash { data: input[..32].try_into().unwrap() },
+        ZkvmSecp256r1Signature { data: input[32..96].try_into().unwrap() },
+        ZkvmSecp256r1Pubkey { data: input[96..].try_into().unwrap() },
+    )
+}
+
+const VALID: [u8; 160] = hex!(
+    "4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4d"
+    "a73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac"
+    "36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d60"
+    "4aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff3"
+    "7618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e"
+);
+
+#[test]
+fn secp256r1_verify_vectors() {
+    let (msg, sig, pubkey) = parts(&VALID);
+    let mut verified = false;
+
+    secp256r1_verify(&msg, &sig, &pubkey, &mut verified).unwrap();
+    assert!(verified);
+
+    // Wrong message must not verify; `verified` must be overwritten.
+    let mut wrong_msg = msg;
+    wrong_msg.data[0] = 0x3c;
+    secp256r1_verify(&wrong_msg, &sig, &pubkey, &mut verified).unwrap();
+    assert!(!verified);
+}
+
+#[test]
+fn secp256r1_verify_malformed_inputs() {
+    let (msg, sig, _) = parts(&VALID);
+    let mut verified = true;
+
+    // A signature with out-of-range values cannot be parsed.
+    let bad_sig = ZkvmSecp256r1Signature { data: [0xff; 64] };
+    let result = secp256r1_verify(&msg, &bad_sig, &parts(&VALID).2, &mut verified);
+    assert_eq!(result, Err(Error::InvalidSignature));
+    assert!(!verified);
+
+    // A public key that is not on the curve cannot be parsed.
+    verified = true;
+    let bad_pubkey = ZkvmSecp256r1Pubkey { data: [0; 64] };
+    let result = secp256r1_verify(&msg, &sig, &bad_pubkey, &mut verified);
+    assert_eq!(result, Err(Error::PointNotOnCurve));
+    assert!(!verified);
+}

--- a/crates/accelerators/tests/conformance/main.rs
+++ b/crates/accelerators/tests/conformance/main.rs
@@ -4,4 +4,5 @@
 //! Modules mirror the `src/ops` layout: one file per domain.
 
 mod blake2;
+mod ecdsa;
 mod hash;


### PR DESCRIPTION
Third PR of the zkVM accelerators C interface series: adds `zkvm_secp256k1_ecrecover`, `zkvm_secp256k1_verify` and `zkvm_secp256r1_verify` with their ops implementations and tests.

`secp256k1.rs` and `secp256r1.rs` contain their respective function implementation. For the `secp256k1_ecrecover` to work on host, we use RustCrypto k256 crate. 

resolves INT-8934