### PR TITLE
fix: do `assert_reduced` before serializing field elements

### DIFF
--- a/crates/accelerators/src/bls12_381/codec.rs
+++ b/crates/accelerators/src/bls12_381/codec.rs
@@ -58,6 +58,8 @@ pub(super) fn encode_g1(point: &bls::G1Affine) -> [u8; 96] {
         return output;
     }
 
+    point.x().assert_reduced();
+    point.y().assert_reduced();
     let x: &[u8] = point.x().as_le_bytes();
     let y: &[u8] = point.y().as_le_bytes();
     for index in 0..FP_LEN {
@@ -76,6 +78,10 @@ pub(super) fn encode_g2(point: &bls::G2Affine) -> [u8; 192] {
 
     let x = point.x();
     let y = point.y();
+    x.c0.assert_reduced();
+    x.c1.assert_reduced();
+    y.c0.assert_reduced();
+    y.c1.assert_reduced();
     let x_c0 = x.c0.as_le_bytes();
     let x_c1 = x.c1.as_le_bytes();
     let y_c0 = y.c0.as_le_bytes();

--- a/crates/accelerators/src/bn254/codec.rs
+++ b/crates/accelerators/src/bn254/codec.rs
@@ -44,6 +44,8 @@ pub(super) fn read_scalar(input: &[u8; 32]) -> bn::Scalar {
 #[inline]
 pub(super) fn encode_g1(point: bn::G1Affine) -> [u8; 64] {
     let mut output = [0; 64];
+    point.x().assert_reduced();
+    point.y().assert_reduced();
     let x: &[u8] = point.x().as_le_bytes();
     let y: &[u8] = point.y().as_le_bytes();
     for index in 0..FQ_LEN {

--- a/crates/accelerators/src/modexp.rs
+++ b/crates/accelerators/src/modexp.rs
@@ -87,7 +87,9 @@ fn accelerated_modexp_bn254_fr(base: &[u8], exp: &[u8]) -> Vec<u8> {
     let mut padded = vec![0u8; padded_len];
     padded[padded_len - base.len()..].copy_from_slice(base);
     let base_fr = bn::Scalar::reduce_be_bytes(&padded);
-    base_fr.exp_bytes(true, exp).to_be_bytes().as_ref().to_vec()
+    let result = base_fr.exp_bytes(true, exp);
+    result.assert_reduced();
+    result.to_be_bytes().as_ref().to_vec()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The output of the `FieldExpr` is only constrained up to congruence mod p so it could be non-canonical if I understand correctly, this PR adds `assert_reduced` before doing serialization to make sure the output is unique.
